### PR TITLE
feat: initial plugin scaffold (v0.1.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "tomas-cursor",
+  "owner": {
+    "name": "Tomas Grasl",
+    "url": "https://www.tomasgrasl.cz/"
+  },
+  "plugins": [
+    {
+      "name": "cursor",
+      "source": "./plugins/cursor",
+      "description": "Delegate coding tasks from Claude Code to Cursor CLI (Composer 2 by default).",
+      "strict": false
+    }
+  ]
+}

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: ${{ matrix.os }} / node ${{ matrix.node }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        node: ['18.18', '20', '22']
+    defaults:
+      run:
+        working-directory: plugins/cursor
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+          cache-dependency-path: plugins/cursor/package-lock.json
+
+      - run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test
+
+      - name: Lint
+        run: npm run lint

--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,18 @@ dist
 # Vite logs files
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# cursor-plugin-cc local state
+.cursor-plugin-cc/
+
+# macOS
+.DS_Store
+
+# Test coverage
+coverage/
+
+# Plan files (workspace-local)
+.claude/plans/
+
+# Claude Code per-developer settings
+.claude/settings.local.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Planned
+
+- Support additional browser-automation MCPs (next target: Mozilla [firefox-devtools-mcp](https://github.com/mozilla/firefox-devtools-mcp)). `/cursor:browser` will grow a `--mcp <name>` flag and autodiscover from `cursor-agent mcp list`.
+- Repo-local `.cursor-plugin-cc.json` for per-project default model / timeout / MCP preference.
+- npm publish with shipped `dist/` so the `npm install` step can go away.
+
+## 0.1.0 — initial release
+
+### Added
+
+- `/cursor:delegate` — hand a coding task to `cursor-agent`, with background and resume support. Default model is `composer-2-fast` (Cursor's own current default, fastest Composer variant).
+- `/cursor:browser <url> <what to verify>` — read-only browser verification via Cursor's `chrome-devtools` MCP. Pre-checks MCP availability, bakes in `--approve-mcps`, scripts the standard `list_pages → navigate → take_snapshot → interact → wait_for → console/network` flow.
+- `/cursor:status` — list or inspect tracked jobs for the current repository.
+- `/cursor:result` — fetch the final output of a completed job.
+- `/cursor:cancel` — cancel an active job (SIGTERM → SIGKILL after 5 s).
+- `/cursor:resume` — shortcut for `/cursor:delegate --resume`.
+- `/cursor:sessions` — list Cursor's own chat sessions via `cursor-agent ls`.
+- `/cursor:setup` — health-check, model listing, configured-MCP listing, and optional installer.
+- `cursor-runner` subagent for automated task delegation.
+- File-backed job registry under `~/.cursor-plugin-cc/jobs/<repo-hash>/`.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,11 @@
+cursor-plugin-cc
+Copyright (c) 2026 Tomas Grasl
+
+Licensed under the MIT License. See LICENSE for details.
+
+This project integrates with the Cursor CLI (`cursor-agent`), which is a
+separate product of Cursor / Anysphere. The Cursor CLI is not bundled or
+redistributed here; users must install it independently from
+https://cursor.com/install.
+
+Inspired by the structure of openai/codex-plugin-cc (MIT-licensed).

--- a/README.md
+++ b/README.md
@@ -1,2 +1,286 @@
 # cursor-plugin-cc
-Use Cursor CLI from Claude Code to delegate coding tasks to Composer 2 and other Cursor models.
+
+> Use Cursor CLI from Claude Code to delegate coding tasks to Composer 2 and other Cursor models.
+
+[![CI](https://github.com/freema/cursor-plugin-cc/actions/workflows/ci.yml/badge.svg)](https://github.com/freema/cursor-plugin-cc/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
+[![Node.js](https://img.shields.io/badge/node-%E2%89%A5%2018.18-43853d.svg)](https://nodejs.org)
+[![Claude Code plugin](https://img.shields.io/badge/Claude%20Code-plugin-7c3aed.svg)](https://claude.com/claude-code)
+[![Cursor CLI](https://img.shields.io/badge/Cursor-cursor--agent-000000.svg)](https://cursor.com)
+
+A [Claude Code](https://claude.com/claude-code) plugin that hands off coding tasks from Claude to the Cursor CLI (`cursor-agent`). Claude stays the planner and reviewer; Cursor is the fast executor — `composer-2-fast` by default (Cursor's own current default, and the fastest Composer variant), in force/yolo mode, optionally in the background.
+
+## What you get
+
+Eight slash commands under the `cursor:` namespace:
+
+- **`/cursor:delegate`** — hand a coding task to Cursor, foreground or background.
+- **`/cursor:browser`** — verify a URL / flow in a real browser via Cursor's `chrome-devtools` MCP.
+- **`/cursor:status`** — list recent jobs or inspect a specific one.
+- **`/cursor:result`** — print the final output of a finished job.
+- **`/cursor:cancel`** — terminate a running job (SIGTERM, then SIGKILL after 5 s).
+- **`/cursor:resume`** — continue the previous Cursor chat with a follow-up.
+- **`/cursor:sessions`** — list Cursor's own chat sessions for this repo.
+- **`/cursor:setup`** — health-check the CLI, list models + configured MCPs, or guide installation.
+
+Plus a `cursor-runner` subagent you can invoke from inside Claude to delegate well-scoped tasks automatically.
+
+## Why this plugin
+
+Short answer: **Composer 2 is genuinely good at most day-to-day coding work** — and I don't want a pile of terminal windows to drive it. I want Claude Code to be the orchestrator for everything. The flow that keeps working for me is simple: **Claude makes the plan, Composer executes it, Claude reviews the diff.** Two tools, each doing what it is best at.
+
+"Why not do the whole thing inside Cursor, then?" Claude Code has a certain magic, particularly around planning. It is not purely about the underlying model — it is the whole rig (long-context sessions, subagents, the TUI, the way tools compose) that, in my experience, only really clicks inside Claude Code.
+
+Cursor CLI has its own plan mode and it is fine, but execution is where Cursor really shines: file edits, applying diffs, crunching through a well-scoped task list in force mode. Cursor 2 and the Composer models are heavily tuned for exactly that CLI use-case. (The same is true of Codex and GPT on OpenAI's side, which is why [`openai/codex-plugin-cc`](https://github.com/openai/codex-plugin-cc) exists — and which is what I borrowed from heavily when building this plugin. Credit where due.)
+
+So: Claude plans, Cursor writes, Claude reviews, repeat. Glued together by seven slash commands and one subagent.
+
+## Why not just `/codex:review`-style?
+
+This plugin is built around delegating _execution_ — writing code — to Cursor's Composer 2 for speed. Claude Code stays the orchestrator, planner, and reviewer. There is intentionally **no** `/cursor:review` or `/cursor:adversarial-review` command: Cursor is the "doer" here, not the critic. If you want review, ask Claude to review Cursor's diff in the usual way.
+
+## Requirements
+
+- Node.js **≥ 18.18**
+- A Cursor subscription (Composer 2 is included in paid tiers)
+- `cursor-agent` on your `PATH` — install via `curl https://cursor.com/install -fsS | bash`
+- `cursor-agent login` completed at least once
+
+## Install
+
+Local, for immediate testing from this repository:
+
+```
+/plugin marketplace add /Users/you/path/to/cursor-plugin-cc
+/plugin install cursor@tomas-cursor
+/reload-plugins
+/cursor:setup
+```
+
+From GitHub once published:
+
+```
+/plugin marketplace add freema/cursor-plugin-cc
+/plugin install cursor@tomas-cursor
+/reload-plugins
+/cursor:setup
+```
+
+> ⚠️ **Do not skip `/reload-plugins`.** Right after `/plugin install` the `/cursor:*` commands are NOT yet available — Claude Code only picks them up after a plugin reload. If you see `Unknown command: /cursor:setup`, you forgot this step — run `/reload-plugins` and try again.
+
+> ⚠️ **One-time `npm install`.** The plugin ships as TypeScript and runs via `tsx` — the Claude Code plugin loader does not run `npm install` for you. Inside the plugin directory run it once:
+>
+> ```bash
+> cd plugins/cursor && npm install
+> ```
+>
+> (When you installed from a local path as above, the path is simply your clone's `plugins/cursor`. When installed via `/plugin marketplace add freema/cursor-plugin-cc` from GitHub, Claude Code unpacks the repo under `~/.claude/plugins/cache/<id>/` — run `npm install` inside that cache's `plugins/cursor/`.)
+
+The first `/cursor:setup` run tells you if `cursor-agent` is missing, unauthenticated, or if `node_modules` are not yet installed.
+
+## Usage
+
+### `/cursor:delegate <task...>`
+
+Hand a coding task to `cursor-agent -p …`.
+
+| Flag                   | Default                    | Effect                                                                                                                                                                                                                                                                                                                                                         |
+| ---------------------- | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--model <id>`         | `composer-2-fast`          | Aliases → real Cursor ids: `composer`/`fast` → `composer-2-fast`, `composer-2` → `composer-2`, `sonnet` → `claude-4.6-sonnet-medium`, `opus` → `claude-opus-4-7-high`, `gpt`/`codex` → `gpt-5.3-codex`, `grok` → `grok-4-20`, `gemini` → `gemini-3.1-pro`, `auto` → `auto`. Unknown ids forwarded as-is. Run `/cursor:setup --print-models` for the live list. |
+| `--background`         | off                        | Detach; the command returns a job id immediately.                                                                                                                                                                                                                                                                                                              |
+| `--wait`               | on (if not `--background`) | Block until finished.                                                                                                                                                                                                                                                                                                                                          |
+| `--fresh`              | off                        | Start a brand-new Cursor session (no resume).                                                                                                                                                                                                                                                                                                                  |
+| `--resume[=<chat-id>]` | off                        | Resume a prior chat. With no id, resume the latest for this repo.                                                                                                                                                                                                                                                                                              |
+| `--no-force`           | `--force` is ON            | Disable auto-approve (paranoid mode).                                                                                                                                                                                                                                                                                                                          |
+| `--cloud`              | off                        | Pass `-c` to cursor-agent.                                                                                                                                                                                                                                                                                                                                     |
+| `--timeout <sec>`      | `1800`                     | Kill the job if it exceeds this.                                                                                                                                                                                                                                                                                                                               |
+| `--no-git-check`       | off                        | Allow running outside a git repo.                                                                                                                                                                                                                                                                                                                              |
+
+Examples:
+
+```
+/cursor:delegate add a dark-mode toggle to the settings page
+/cursor:delegate --model composer "write jest tests for utils/date.ts"
+/cursor:delegate --background --model auto "migrate user repository to Doctrine 3"
+/cursor:delegate --resume "continue with the failing edge case"
+```
+
+### `/cursor:browser <url> <what to verify...>`
+
+Verify a page or a flow in a **real browser** via Cursor's `chrome-devtools` MCP. This is read-only by design — Cursor navigates, interacts, checks console/network and reports back; it will not modify your source files.
+
+```
+/cursor:browser http://localhost:3000 "login flow works for valid and invalid credentials"
+/cursor:browser http://localhost:5173 "dark-mode toggle persists across reloads"
+/cursor:browser localhost:8080 "no console errors on the home page; no 4xx/5xx requests"
+```
+
+Under the hood: the command pre-checks that `chrome-devtools` is configured in `cursor-agent mcp list`, then invokes `cursor-agent -p --approve-mcps …` with a prompt that scripts the standard flow (`list_pages → navigate → take_snapshot → interact → wait_for → console/network checks → screenshot`). No flags to remember.
+
+**Setup for this command** (one-time): add the MCP server to your Cursor MCP config, usually `~/.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "chrome-devtools": {
+      "command": "npx",
+      "args": ["-y", "chrome-devtools-mcp@latest", "--isolated"]
+    }
+  }
+}
+```
+
+Restart Cursor so `cursor-agent` picks up the new MCP. `--isolated` makes each run use a fresh Chrome profile, which sidesteps the common "profile already in use" lockout.
+
+Verify with `/cursor:setup --doctor` — it now lists every MCP `cursor-agent` can see and whether each is loaded.
+
+### `/cursor:status [job-id] [--all]`
+
+Without args, shows the last 10 jobs for this repository as a table. With an id, shows the full job record including the Cursor chat id (so you can resume manually with `cursor-agent --resume=<id>`). Pass `--all` to drop the 10-row limit.
+
+```
+/cursor:status
+/cursor:status V1StGXR8_Z
+```
+
+### `/cursor:result [job-id]`
+
+Prints the final summary of a finished job. Defaults to the most recent one for this repo.
+
+```
+/cursor:result
+/cursor:result V1StGXR8_Z
+```
+
+### `/cursor:cancel [job-id]`
+
+Cancels a running job. With no id, cancels the single running job (errors if there are several).
+
+```
+/cursor:cancel
+/cursor:cancel V1StGXR8_Z
+```
+
+### `/cursor:resume [task...]`
+
+Shortcut for `/cursor:delegate --resume <task...>`. Without a task, sends an empty follow-up ("continue").
+
+```
+/cursor:resume "now wire it into the App shell"
+/cursor:resume --resume=chat_abc123 "fix the failing test"
+```
+
+### `/cursor:sessions`
+
+Shells out to `cursor-agent ls` and lists Cursor's own chat sessions for this repo. If that call times out or returns empty, the plugin falls back to its local job registry.
+
+### `/cursor:setup [--doctor] [--print-models] [--install]`
+
+Runs a quick health-check. `--doctor` produces extended diagnostics (Node version, PATH, `CURSOR_API_KEY` presence masked, jobs dir writability, cursor-agent version). `--print-models` shells out to `cursor-agent --list-models`. `--install` prints the install command but **does not run it** — you must copy-paste it yourself.
+
+## The two-phase loop
+
+This plugin is built around one pattern: **Claude plans and reviews, Cursor writes code.** Treat them as two separate roles, not one pipeline:
+
+1. **Plan / spec** — Claude Code scopes the change, picks the slice to delegate, and drafts acceptance criteria. This is where architectural judgment happens.
+2. **Execute** — `/cursor:delegate` (or the `cursor-runner` subagent) hands that spec to Cursor. Cursor writes files under `--force`, fast.
+3. **Review** — Claude reads the diff Cursor produced. This is where correctness and style are checked.
+4. **Iterate** — `/cursor:resume "fix X"` for the same thread, or `/cursor:delegate --fresh` for a new slice.
+
+The plugin intentionally does not try to collapse these phases into one. Cursor is fast but context-starved; Claude has the whole session context but is slower per edit. Keeping them in separate phases is the whole point.
+
+### Writing good prompts for Cursor
+
+A good `/cursor:delegate` prompt has five sections:
+
+1. **Goal** — one sentence.
+2. **Repo context** — stack, and a pointer to whatever conventions file applies (`AGENTS.md`, `.cursor/rules`, `CLAUDE.md`).
+3. **Acceptance criteria** — 1–5 verifiable bullets.
+4. **Files to touch** — explicit list when you can predict it.
+5. **How to verify** — the exact commands (`npm test`, `task typecheck`, …) that prove the task is done.
+
+The `cursor-runner` subagent applies this template automatically. When you write `/cursor:delegate` by hand, aim for the same structure in the task string — it is the single biggest lever on Cursor's output quality.
+
+### Chunking
+
+`cursor-agent --force` will YOLO through whatever you give it. Keep slices small: **≤ 5 steps, ≤ 10 files, ≤ 2 architectural layers per `/cursor:delegate` call.** If the plan is bigger, split it — one slice per call — and let Claude review between slices.
+
+### Language and target-repo conventions
+
+The plugin codebase is English, but it does not impose a language policy on **your** repo. When the `cursor-runner` subagent prepares a prompt, it reads the target repo's `AGENTS.md` / `.cursor/rules` / existing code and tells Cursor to match that style — whether that means Czech commits, German UI strings, or anything else. Do not put "write everything in English" in your own prompts unless that is actually your repo's convention.
+
+## Typical flows
+
+**Fast parallel task.** You're in Claude Code. You want Cursor to handle something small while you keep working.
+
+```
+/cursor:delegate --background "write jest tests for src/utils/date.ts"
+# keep talking to Claude
+/cursor:result
+```
+
+**Tight loop.** Delegate in the foreground, let Claude review, then iterate.
+
+```
+/cursor:delegate "extract the retry logic from apiClient.ts into a hook"
+# Claude reads the diff, suggests a fix
+/cursor:resume "also add a unit test for the 429 path"
+```
+
+**Escalation.** Start small, upgrade if Cursor stalls.
+
+```
+/cursor:delegate --model composer "<task>"
+# composer gave up — retry with opus from scratch
+/cursor:delegate --model opus --fresh "<same task>"
+```
+
+**Resume vs fresh.** Use `--resume` (default) when the new task is the same thread of work. Use `--fresh` when the topic changed, or when the previous run went off the rails and resuming would just carry the confusion forward.
+
+## Configuration
+
+| Env var                 | Purpose                                                                         |
+| ----------------------- | ------------------------------------------------------------------------------- |
+| `CURSOR_API_KEY`        | Forwarded to `cursor-agent`. Optional — `cursor-agent login` is usually enough. |
+| `CURSOR_AGENT_BIN`      | Override binary path (used by the test suite).                                  |
+| `CURSOR_PLUGIN_CC_HOME` | Override the jobs-registry root (default `~/.cursor-plugin-cc`).                |
+
+A repo-local `.cursor-plugin-cc.json` is on the roadmap for overriding the default model per repo; until then, set `--model` per invocation.
+
+## Moving work back to Cursor
+
+Every finished job stores the Cursor `chat_id`. Read it from `/cursor:status <job-id>` or `/cursor:result`. Then, in any terminal:
+
+```
+cursor-agent --resume=<chat_id>
+```
+
+This re-opens the same Cursor session without going through Claude Code — handy when you want to finish something in Cursor's interactive UI.
+
+## FAQ
+
+**Does it need a special Node version?** Yes — ≥ 18.18. The CI matrix tests 18.18, 20, and 22 on Linux and macOS.
+
+**Does it use my existing Cursor auth?** Yes. The plugin shells out to your already-installed `cursor-agent`, which uses whatever session `cursor-agent login` set up (or `CURSOR_API_KEY` if you prefer).
+
+**Does it upload my code anywhere?** No — the plugin itself runs locally. `cursor-agent` of course sends your prompts to Cursor's backend; that is Cursor's normal behaviour, not something this plugin changes.
+
+**What does `--force` do?** It is Cursor's auto-approve (aka `--yolo`). With it on, Cursor writes files without asking each time. This is necessary for non-interactive use but means Cursor can touch your working tree freely. Use `--no-force` if you want to test against an interactive flow — but note that most headless invocations will hang waiting for approval, so `--no-force` is really only useful for debugging.
+
+**The model list doesn't match what I see in Cursor.** Run `/cursor:setup --print-models` — that shells out to `cursor-agent --list-models` and shows exactly what your account supports. The alias table in the plugin is a convenience; Cursor's actual model IDs drift over time.
+
+**`cursor-agent` hangs after finishing a task.** Known quirk of the print-mode CLI. The plugin has a 5-second watchdog that SIGTERMs the process after a `result` event if it hasn't self-exited, then SIGKILLs 5 seconds later.
+
+## Roadmap
+
+Things that are **not** in 0.1.0 but on the list:
+
+- **Additional browser MCPs** — right now `/cursor:browser` hard-codes `chrome-devtools` as the MCP name. Planned: a `--mcp <name>` flag plus autodiscovery so any DevTools-style MCP works. First follow-up target: Mozilla's [firefox-devtools-mcp](https://github.com/mozilla/firefox-devtools-mcp).
+- **Per-repo defaults** — a `.cursor-plugin-cc.json` at repo root to override default model, timeout and MCP preference without re-typing flags.
+- **npm publish** — once the API stabilises, ship a tarball so users can `/plugin install cursor@tomas-cursor` without a `cd plugins/cursor && npm install` step.
+
+Contributions and ideas welcome.
+
+## License
+
+MIT — see [LICENSE](./LICENSE). See also [NOTICE](./NOTICE).

--- a/README.md
+++ b/README.md
@@ -237,6 +237,19 @@ The plugin codebase is English, but it does not impose a language policy on **yo
 
 **Resume vs fresh.** Use `--resume` (default) when the new task is the same thread of work. Use `--fresh` when the topic changed, or when the previous run went off the rails and resuming would just carry the confusion forward.
 
+## How I actually use this (the recipe I run every day)
+
+The two-phase loop above is the concept; here is the concrete workflow that falls out of it in practice, and the one I keep reaching for:
+
+1. **Plan in Claude Code and write a task file.** Describe what you want; ask Claude to draft a _task spec_ — a markdown file with **goal**, **acceptance criteria**, **files to touch**, and **how to verify** (the same five sections the `cursor-runner` subagent enforces). Save it under `tasks/<slug>.md` in the repo.
+2. **Hand the file to Cursor.** Run `/cursor:delegate @tasks/<slug>.md implement this`. The `@path` shorthand inlines the file contents into the prompt, so Cursor gets the full spec without Claude having to re-type it. Composer 2 executes — it is genuinely fast, and a precisely defined task is usually a one-shot job.
+3. **Back in Claude Code: review the diff.** Approve, or iterate with `/cursor:resume "fix X"` on the same thread, or escalate with `/cursor:delegate --model opus --fresh <same task file>` if Composer stalled.
+4. **Keep the task files around.** `tasks/` becomes a little log of what the repo's delegated changes looked like. Handy when you want to re-delegate a similar slice — just copy an old file, tweak the bullets.
+
+Why this works: Claude's tokens go into **planning and reviewing**, where thinking matters; Cursor's Composer 2 handles **the actual typing**, where it is cheaper and faster. The task file is the contract between the two phases — if it is sloppy, no model will save you. Writing a good one is itself a skill, and it is the only skill this workflow asks of you.
+
+If you want Claude to do the whole thing automatically — draft the task file AND hand it off — that is what the `cursor-runner` subagent is for. Ask it to either "draft a task file for X" (it stops there) or "implement X via Cursor" (it drafts, hands off, and reports the diff).
+
 ## Configuration
 
 | Env var                 | Purpose                                                                         |

--- a/plugins/cursor/.prettierignore
+++ b/plugins/cursor/.prettierignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+coverage
+package-lock.json
+*.ndjson
+.cursor-plugin-cc

--- a/plugins/cursor/.prettierrc
+++ b/plugins/cursor/.prettierrc
@@ -1,0 +1,10 @@
+{
+  "printWidth": 100,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "arrowParens": "always",
+  "endOfLine": "lf"
+}

--- a/plugins/cursor/agents/cursor-runner.md
+++ b/plugins/cursor/agents/cursor-runner.md
@@ -1,0 +1,104 @@
+---
+name: cursor-runner
+description: Hand off a well-specified coding task to the Cursor CLI (`cursor-agent`) via `/cursor:delegate`. Use for small-to-medium, well-scoped changes where speed matters (default model `composer-2-fast`). Do NOT use this agent for code review, design decisions, or large refactors — those stay with the main Claude conversation.
+tools: [Bash, Read]
+---
+
+You are the **cursor-runner** subagent. Your single job is to delegate a concrete coding task to Cursor CLI and then report the outcome back to the main Claude conversation. You are a forwarder, not an implementer.
+
+## The loop you are part of
+
+The plugin's core pattern is a **two-phase loop**:
+
+1. **Main Claude** plans the change, decides scope, and drafts the task specification.
+2. **You (cursor-runner)** translate that spec into a tight, self-contained Cursor prompt and run `/cursor:delegate`.
+3. **Cursor** writes the code (fast executor, auto-approves file edits under `--force`).
+4. **Main Claude** reviews the diff Cursor produced and iterates — via `/cursor:resume` or a fresh `/cursor:delegate`.
+
+Your job is step 2 only. Never do steps 1, 3, or 4 yourself.
+
+## What you must do
+
+### 1. Read the target repo's conventions before writing the prompt
+
+Cursor has no conversation context — whatever the target repo expects, you must bake into the prompt you send. **Use `Read` (only) to check for:**
+
+- `AGENTS.md`, `CLAUDE.md`, `.cursor/rules/**`, `.github/copilot-instructions.md`, `CONTRIBUTING.md` — convention files.
+- `package.json` / `Taskfile.yml` / `Makefile` / `justfile` — to learn which commands build and test the project.
+- `README.md` — for the overall project goal (one sentence is enough).
+
+**Language and style follow the target repo, not this plugin.** If the target repo's commits, comments, or UI strings are in Czech / German / any other language, Cursor must match — do not force English. If the repo is mixed (e.g. code in English, user-facing copy in Czech), say so explicitly in the prompt. When in doubt, tell Cursor: "match the existing style of surrounding files."
+
+### 2. Write a tight, self-contained prompt for Cursor
+
+Every prompt you send **must** have these sections, in this order:
+
+1. **Goal** — one or two sentences. What is the outcome? What is this a step of, if anything?
+2. **Repo context** — 1–2 lines: stack / framework, and "follow conventions in `AGENTS.md` / `.cursor/rules` / whichever you actually found."
+3. **Acceptance criteria** — 1–5 bullet points, concrete and verifiable.
+4. **Files to touch** — an explicit list. Unless the task inherently cannot predict this, Cursor must not wander outside it.
+5. **How to verify** — the exact commands that prove the task is done (e.g. `npm test`, `task typecheck && task test`, `pnpm lint`). This is not optional — without it Cursor will declare "done" on unverified work.
+6. **Guardrails** — short and blunt:
+   - Do not delete files outside the list.
+   - Do not rename public APIs unless asked.
+   - Do not touch lockfiles (`package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`) unless the task is explicitly about dependencies.
+   - If a pre-existing test is already failing, report it — do not "fix" it as a side task.
+
+### 3. Chunk oversized plans before delegating
+
+`cursor-agent --force` will YOLO through anything you hand it. That is the point — and also the risk. **Refuse to delegate a single monolithic blob of work.** Heuristics:
+
+- If the plan has **more than ~5 discrete steps**, split into one `/cursor:delegate` call per step (or per coherent slice).
+- If the plan touches **more than ~10 files** or crosses **more than 2 architectural layers**, ask the main Claude to narrow the slice first.
+- If you cannot name the acceptance criteria in ≤ 5 bullets, the slice is still too big.
+
+Small slices give Cursor a tight scope, make the diff reviewable, and make failures cheap to retry.
+
+### 4. Pick a model
+
+Default is `composer-2-fast` — Cursor's own current default and the fastest Composer variant. Escalate only when the task warrants it:
+
+- `composer-2` (non-fast) — quality matters slightly more than latency, but the task is still well-scoped.
+- `sonnet` (`claude-4.6-sonnet-medium`) — more than ~5 files touched, or moderate architecture changes.
+- `opus` (`claude-opus-4-7-high`) — cross-cutting refactor, subtle correctness, or a prior `composer` run failed.
+- `gpt` / `codex` (`gpt-5.3-codex`) — only when the user explicitly asks for it.
+
+Unknown aliases are forwarded as-is, so `--model <whatever>` always works.
+
+### 5. Decide: resume or fresh
+
+- **`--resume`** (default when not specified): continue the latest Cursor chat for this repo. Use it when you are **iterating on the same task** — e.g. "also cover the 429 path", "rename the helper you just added". Cheap, preserves Cursor's mental model.
+- **`--resume=<chat-id>`**: same as above but target a specific prior chat — use when `/cursor:status` or the user pointed you at one explicitly.
+- **`--fresh`**: start a brand-new Cursor session. Use it when **the new task has nothing to do with the previous one**, or when the previous run went off the rails and resuming would just carry the confusion forward.
+
+When in doubt: fresh if the task topic changed, resume if it's the same thread of work.
+
+### 6. Invoke `/cursor:delegate` via a single `Bash` call
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/node_modules/.bin/tsx" \
+  "${CLAUDE_PLUGIN_ROOT}/plugins/cursor/scripts/delegate.ts" \
+  -- --model fast "<prompt>"
+```
+
+Use `--background` only if the user explicitly asked for it, or the task obviously exceeds ~5 minutes.
+
+### 7. Return Cursor's output verbatim
+
+Do not paraphrase the summary, do not rewrite the file list, do not hide the chat id. The main Claude will read the diff and decide what comes next.
+
+## What you must NOT do
+
+- **Do not edit files yourself.** Use `Read` only to ground the prompt you send to Cursor — never to patch code directly.
+- **Do not review Cursor's diff.** Review is the main Claude conversation's job. Your job ends when you hand back Cursor's report.
+- **Do not run `/cursor:status`, `/cursor:result`, or `/cursor:cancel` on your own.** If the main conversation wants them, it will run them itself.
+- **Do not escalate models without a reason.** `composer-2-fast` is the default for a reason (speed + cost). Escalate only when the task description itself warrants it.
+- **Do not impose a language policy on the target repo.** Follow whatever conventions the target repo's `AGENTS.md` / `.cursor/rules` / existing code already establishes.
+
+## Output format
+
+Return exactly what `delegate.ts` prints. One line of your own framing is fine:
+
+> Delegated to Cursor (`composer-2-fast`). Result below.
+
+Then Cursor's block, unedited.

--- a/plugins/cursor/commands/browser.md
+++ b/plugins/cursor/commands/browser.md
@@ -1,0 +1,9 @@
+---
+description: Verify a page or flow in a real browser via Cursor's `chrome-devtools` MCP. Read-only — Cursor reports; does not modify source files.
+argument-hint: '<url> <what to verify...>'
+allowed-tools: Bash(node:*)
+---
+
+!`node "${CLAUDE_PLUGIN_ROOT}/dist/browser.js" -- "$ARGUMENTS"`
+
+Present the browser report verbatim. If the preflight fails because the `chrome-devtools` MCP is not configured, relay the setup instructions from the error to the user — do not try to install or configure the MCP yourself.

--- a/plugins/cursor/commands/cancel.md
+++ b/plugins/cursor/commands/cancel.md
@@ -1,0 +1,9 @@
+---
+description: Cancel an active Cursor job (SIGTERM, then SIGKILL after 5 s).
+argument-hint: '[job-id]'
+allowed-tools: Bash(node:*)
+---
+
+!`node "${CLAUDE_PLUGIN_ROOT}/dist/cancel.js" -- "$ARGUMENTS"`
+
+Surface the cancellation result to the user. If multiple running jobs exist, forward the error and ask which id to cancel.

--- a/plugins/cursor/commands/delegate.md
+++ b/plugins/cursor/commands/delegate.md
@@ -1,0 +1,9 @@
+---
+description: Delegate a coding task to the Cursor CLI agent (Composer 2 by default).
+argument-hint: '[--background] [--wait] [--fresh] [--resume[=chat-id]] [--model <id>] [--cloud] [--no-force] [--timeout <sec>] <task...>'
+allowed-tools: Bash(node:*)
+---
+
+!`node "${CLAUDE_PLUGIN_ROOT}/dist/delegate.js" -- "$ARGUMENTS"`
+
+Render the tool output to the user verbatim. If the job ran in the foreground, present the status, files touched, and summary sections as a compact Markdown block. If the job was started in the background, show the returned job id and the `/cursor:status` hint. Do not paraphrase Cursor's summary.

--- a/plugins/cursor/commands/result.md
+++ b/plugins/cursor/commands/result.md
@@ -1,0 +1,9 @@
+---
+description: Print the final output of a finished Cursor job (most recent by default).
+argument-hint: '[job-id]'
+allowed-tools: Bash(node:*)
+---
+
+!`node "${CLAUDE_PLUGIN_ROOT}/dist/result.js" -- "$ARGUMENTS"`
+
+Show the result block to the user as-is. Do not truncate or summarise — the user invoked this command specifically to see the full summary. End by noting the `cursor-agent --resume=…` line if present.

--- a/plugins/cursor/commands/resume.md
+++ b/plugins/cursor/commands/resume.md
@@ -1,0 +1,9 @@
+---
+description: Resume the latest Cursor chat (or a specific one) with an optional follow-up prompt.
+argument-hint: '[--resume=chat-id] [--model <id>] [--background] [follow-up task...]'
+allowed-tools: Bash(node:*)
+---
+
+!`node "${CLAUDE_PLUGIN_ROOT}/dist/resume.js" -- "$ARGUMENTS"`
+
+Treat the output identically to `/cursor:delegate` — it is the same pipeline, just with `--resume` injected.

--- a/plugins/cursor/commands/sessions.md
+++ b/plugins/cursor/commands/sessions.md
@@ -1,0 +1,9 @@
+---
+description: List Cursor chat sessions for this repository via `cursor-agent ls`.
+argument-hint: ''
+allowed-tools: Bash(node:*)
+---
+
+!`node "${CLAUDE_PLUGIN_ROOT}/dist/sessions.js"`
+
+Render the table verbatim. If `cursor-agent ls` was unavailable and the fallback registry listing was shown, surface that note too so the user knows why the columns differ.

--- a/plugins/cursor/commands/setup.md
+++ b/plugins/cursor/commands/setup.md
@@ -1,0 +1,9 @@
+---
+description: Health-check Cursor CLI, list models, or guide installation.
+argument-hint: '[--doctor] [--print-models] [--install]'
+allowed-tools: Bash(node:*)
+---
+
+!`node "${CLAUDE_PLUGIN_ROOT}/dist/setup.js" -- "$ARGUMENTS"`
+
+Present the check results as-is. If any check failed, tell the user concretely what to do (install cursor-agent, run `cursor-agent login`, run `npm install` inside the plugin). Never attempt to run the installer yourself.

--- a/plugins/cursor/commands/status.md
+++ b/plugins/cursor/commands/status.md
@@ -1,0 +1,10 @@
+---
+description: Show active and recent Cursor jobs for this repository.
+argument-hint: '[job-id] [--all]'
+disable-model-invocation: true
+allowed-tools: Bash(node:*)
+---
+
+!`node "${CLAUDE_PLUGIN_ROOT}/dist/status.js" -- "$ARGUMENTS"`
+
+If no id was passed, render the output as a single compact Markdown table. If a specific id was passed, present the full detail block verbatim without summarisation.

--- a/plugins/cursor/eslint.config.js
+++ b/plugins/cursor/eslint.config.js
@@ -1,0 +1,42 @@
+import js from '@eslint/js';
+import tsParser from '@typescript-eslint/parser';
+import tsPlugin from '@typescript-eslint/eslint-plugin';
+
+export default [
+  {
+    ignores: ['node_modules/**', 'dist/**', 'coverage/**', '**/*.ndjson', 'tests/fixtures/**'],
+  },
+  js.configs.recommended,
+  {
+    files: ['**/*.ts'],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        ecmaVersion: 2022,
+        sourceType: 'module',
+      },
+      globals: {
+        console: 'readonly',
+        process: 'readonly',
+        Buffer: 'readonly',
+        setTimeout: 'readonly',
+        clearTimeout: 'readonly',
+        setInterval: 'readonly',
+        clearInterval: 'readonly',
+        setImmediate: 'readonly',
+        URL: 'readonly',
+      },
+    },
+    plugins: {
+      '@typescript-eslint': tsPlugin,
+    },
+    rules: {
+      ...tsPlugin.configs.recommended.rules,
+      'no-unused-vars': 'off',
+      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+      '@typescript-eslint/no-explicit-any': 'warn',
+      'no-undef': 'off',
+      'no-redeclare': 'off',
+    },
+  },
+];

--- a/plugins/cursor/package-lock.json
+++ b/plugins/cursor/package-lock.json
@@ -1,0 +1,4401 @@
+{
+  "name": "cursor-plugin-cc",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cursor-plugin-cc",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^9.5.1",
+        "nanoid": "^5.0.9",
+        "yargs-parser": "^21.1.1",
+        "zod": "^3.23.8"
+      },
+      "devDependencies": {
+        "@eslint/js": "^9.16.0",
+        "@types/node": "^22.10.1",
+        "@types/yargs-parser": "^21.0.3",
+        "@typescript-eslint/eslint-plugin": "^8.18.0",
+        "@typescript-eslint/parser": "^8.18.0",
+        "@vitest/coverage-v8": "^2.1.8",
+        "eslint": "^9.16.0",
+        "prettier": "^3.4.2",
+        "tsx": "^4.19.2",
+        "typescript": "^5.7.2",
+        "vitest": "^2.1.8"
+      },
+      "engines": {
+        "node": ">=18.18"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.0.tgz",
+      "integrity": "sha512-HyAZtpdkgZwpq8Sz3FSUvCR4c+ScbuWa9AksK2Jweub7w4M3yTz4O11AqVJzLYjy/B9ZWPyc81I+mOdJU/bDQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/type-utils": "8.59.0",
+        "@typescript-eslint/utils": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.59.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.0.tgz",
+      "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.0.tgz",
+      "integrity": "sha512-Lw5ITrR5s5TbC19YSvlr63ZfLaJoU6vtKTHyB0GQOpX0W7d5/Ir6vUahWi/8Sps/nOukZQ0IB3SmlxZnjaKVnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.59.0",
+        "@typescript-eslint/types": "^8.59.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.0.tgz",
+      "integrity": "sha512-UzR16Ut8IpA3Mc4DbgAShlPPkVm8xXMWafXxB0BocaVRHs8ZGakAxGRskF7FId3sdk9lgGD73GSFaWmWFDE4dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.0.tgz",
+      "integrity": "sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.0.tgz",
+      "integrity": "sha512-3TRiZaQSltGqGeNrJzzr1+8YcEobKH9rHnqIp/1psfKFmhRQDNMGP5hBufanYTGznwShzVLs3Mz+gDN7HkWfXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0",
+        "@typescript-eslint/utils": "8.59.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.0.tgz",
+      "integrity": "sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.0.tgz",
+      "integrity": "sha512-O9Re9P1BmBLFJyikRbQpLku/QA3/AueZNO9WePLBwQrvkixTmDe8u76B6CYUAITRl/rHawggEqUGn5QIkVRLMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.59.0",
+        "@typescript-eslint/tsconfig-utils": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.0.tgz",
+      "integrity": "sha512-I1R/K7V07XsMJ12Oaxg/O9GfrysGTmCRhvZJBv0RE0NcULMzjqVpR5kRRQjHsz3J/bElU7HwCO7zkqL+MSUz+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.0.tgz",
+      "integrity": "sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-2.1.9.tgz",
+      "integrity": "sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^0.2.3",
+        "debug": "^4.3.7",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.12",
+        "magicast": "^0.3.5",
+        "std-env": "^3.8.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "2.1.9",
+        "vitest": "2.1.9"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.9.tgz",
+      "integrity": "sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/plugins/cursor/package.json
+++ b/plugins/cursor/package.json
@@ -1,0 +1,73 @@
+{
+  "name": "cursor-plugin-cc",
+  "version": "0.1.0",
+  "description": "Use Cursor CLI from Claude Code to delegate coding tasks to Composer 2 and other Cursor models.",
+  "type": "module",
+  "license": "MIT",
+  "author": {
+    "name": "Tomas Grasl",
+    "email": "tomas.grasl@metrifyr.cloud",
+    "url": "https://www.tomasgrasl.cz/"
+  },
+  "homepage": "https://github.com/freema/cursor-plugin-cc",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/freema/cursor-plugin-cc.git"
+  },
+  "keywords": [
+    "claude-code",
+    "claude-code-plugin",
+    "cursor",
+    "cursor-cli",
+    "cursor-agent",
+    "composer-2",
+    "ai-coding",
+    "agent-delegation"
+  ],
+  "engines": {
+    "node": ">=18.18"
+  },
+  "files": [
+    "plugin.json",
+    "scripts",
+    "commands",
+    "agents"
+  ],
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "build": "rm -rf dist && tsc -p tsconfig.build.json",
+    "prepare": "npm run build",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "lint": "prettier --check . && eslint .",
+    "format": "prettier --write .",
+    "delegate": "node dist/delegate.js",
+    "status": "node dist/status.js",
+    "result": "node dist/result.js",
+    "cancel": "node dist/cancel.js",
+    "resume": "node dist/resume.js",
+    "sessions": "node dist/sessions.js",
+    "setup": "node dist/setup.js",
+    "browser": "node dist/browser.js"
+  },
+  "dependencies": {
+    "execa": "^9.5.1",
+    "nanoid": "^5.0.9",
+    "yargs-parser": "^21.1.1",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.16.0",
+    "@types/node": "^22.10.1",
+    "@types/yargs-parser": "^21.0.3",
+    "@typescript-eslint/eslint-plugin": "^8.18.0",
+    "@typescript-eslint/parser": "^8.18.0",
+    "@vitest/coverage-v8": "^2.1.8",
+    "eslint": "^9.16.0",
+    "prettier": "^3.4.2",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2",
+    "vitest": "^2.1.8"
+  }
+}

--- a/plugins/cursor/plugin.json
+++ b/plugins/cursor/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "cursor",
+  "version": "0.1.0",
+  "description": "Hand off tasks from Claude Code to cursor-agent. Composer 2 optimised.",
+  "author": {
+    "name": "Tomas Grasl",
+    "url": "https://www.tomasgrasl.cz/"
+  },
+  "homepage": "https://github.com/freema/cursor-plugin-cc",
+  "repository": "https://github.com/freema/cursor-plugin-cc",
+  "license": "MIT"
+}

--- a/plugins/cursor/scripts/browser.ts
+++ b/plugins/cursor/scripts/browser.ts
@@ -1,0 +1,363 @@
+#!/usr/bin/env node
+import { fileURLToPath } from 'node:url';
+import { nanoid } from 'nanoid';
+import { collapseArguments, parseArgv } from './lib/argv.js';
+import { listConfiguredMcps, resolveModel, runHeadless } from './lib/cursor.js';
+import { isGitRepo, repoRoot } from './lib/git.js';
+import { createJob, rawLogPath as rawLogPathFor, updateJob } from './lib/jobs.js';
+import { ensureDir, jobsDir, logsDir } from './lib/paths.js';
+import { extractChatId, summariseEvents } from './lib/parse.js';
+
+const BOOLEAN_FLAGS = ['background', 'fresh', 'force', 'git-check', 'skip-mcp-check', 'help'];
+const MCP_NAME = 'chrome-devtools';
+
+function buildBrowserPrompt(url: string | undefined, what: string): string {
+  const urlLine = url
+    ? `**Target URL:** ${url}`
+    : `**Target URL:** not supplied — you MUST discover it before testing. In order:\n  1. Call \`list_pages\` and if a \`localhost\` / \`127.0.0.1\` tab is already open, use that.\n  2. Otherwise read the repo for a dev-server URL: \`package.json\` scripts (look for \`dev\`, \`start\`, \`serve\`), \`vite.config.*\`, \`next.config.*\`, \`docker-compose.yml\`, \`.env*\`. Pick the most likely \`http://localhost:<port>\`.\n  3. If you still cannot determine a URL, try \`http://localhost:3000\`, \`:5173\`, \`:4173\`, \`:8080\`, \`:8000\` in that order — \`new_page\` each, \`wait_for\` a non-empty body, stop on the first that loads without a hard network error.\n  4. If NONE respond, stop and report "no dev server reachable" — do not invent a URL.`;
+  return [
+    `Verify the following in a real browser using the \`${MCP_NAME}\` MCP server.`,
+    '',
+    urlLine,
+    `**What to verify:** ${what}`,
+    '',
+    '**Follow this flow (do not skip steps):**',
+    '1. Call `list_pages` to see existing tabs.',
+    `2. If no suitable tab exists, call \`new_page\` with the target URL. Otherwise call \`select_page\` on the right tab and \`navigate_page\` to the target URL (type: "url"). If the target URL was not supplied above, use your discovery result from step 1/2 of the URL-discovery block.`,
+    '3. Call `take_snapshot` to get the accessibility tree with uids. Use those uids for every subsequent `click`, `fill`, `hover`, `press_key` — NEVER blind-click by coordinates or text.',
+    '4. For each interaction that triggers async loading (navigation, form submit, language switch, reload), call `wait_for` with an expected text fragment before continuing.',
+    '5. After the interaction is done, check for problems: call `list_console_messages` filtered to `error` and `list_network_requests` and scan for 4xx/5xx responses. Use `get_network_request` for details on anything suspicious.',
+    '6. If you need runtime state (current locale, auth cookies, feature flags), use `evaluate_script` with a pure function `() => ({...})` returning a JSON-serialisable object. Do not mutate application state via `evaluate_script` unless the test explicitly requires it.',
+    '7. Take a final `take_screenshot` as evidence.',
+    '',
+    '**Report back with:**',
+    '- Overall PASS or FAIL.',
+    '- For each failing assertion: what was expected, what was observed, the relevant console errors (if any), and any failing network responses.',
+    '- The final screenshot filename (if one was captured).',
+    '- Any notable findings that were not part of the explicit verification but look worth flagging.',
+    '',
+    '**Constraints:**',
+    '- This is a **read-only test run.** Do NOT modify any source files, do NOT run `git` commands, do NOT install packages. If you find a bug, report it — do not attempt to fix it.',
+    `- You MUST use the \`${MCP_NAME}\` MCP for every browser interaction. Do NOT fall back to \`curl\`, \`wget\`, \`fetch\`, \`http.get\`, or any shell-based HTTP client — a raw HTTP request is NOT a valid substitute for a browser check (it misses JS execution, DOM rendering, console/network signals). If the MCP is unavailable or a specific tool fails, STOP and report the MCP failure verbatim; do not improvise with anything else.`,
+    '- Canvas-rendered text (e.g. inside `<canvas>` elements from Phaser/WebGL) is not readable via the DOM. For those, either use `evaluate_script` to query whatever the app exposes on `window`, or note the limitation in the report.',
+    '- If the target URL is unreachable or returns a hard error on load, stop immediately and report the network/console evidence instead of pressing on.',
+  ].join('\n');
+}
+
+interface ToolUse {
+  name: string;
+  input: unknown;
+}
+
+// Walks an event tree and yields every `tool_use` block it finds. Cursor's
+// stream-json usually nests tool calls inside `assistant.message.content[]`
+// (matching the Anthropic Messages API), but different models / versions may
+// emit them at the top level, inside `tool`, or inside `tool_use`. We recurse
+// so we don't care about the exact path.
+function* extractToolUses(node: unknown): Iterable<ToolUse> {
+  if (node == null || typeof node !== 'object') return;
+  if (Array.isArray(node)) {
+    for (const item of node) yield* extractToolUses(item);
+    return;
+  }
+  const obj = node as Record<string, unknown>;
+  const type = obj['type'];
+  const name = typeof obj['name'] === 'string' ? (obj['name'] as string) : undefined;
+  if ((type === 'tool_use' || type === 'tool_call') && name) {
+    yield {
+      name,
+      input: obj['input'] ?? obj['arguments'] ?? obj['params'] ?? obj['tool_input'],
+    };
+  }
+  for (const v of Object.values(obj)) yield* extractToolUses(v);
+}
+
+function usedBrowserMcp(events: Array<Record<string, unknown>>): boolean {
+  for (const ev of events) {
+    for (const tu of extractToolUses(ev)) {
+      const name = tu.name.toLowerCase();
+      if (
+        name.includes('chrome') ||
+        name.includes('devtools') ||
+        name.startsWith('mcp_') ||
+        name.includes('take_snapshot') ||
+        name.includes('navigate_page') ||
+        name.includes('list_pages') ||
+        name.includes('new_page') ||
+        name.includes('take_screenshot') ||
+        name.includes('list_console_messages') ||
+        name.includes('list_network_requests') ||
+        name.includes('evaluate_script')
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function usedBannedHttpClient(events: Array<Record<string, unknown>>): string[] {
+  const hits = new Set<string>();
+  for (const ev of events) {
+    for (const tu of extractToolUses(ev)) {
+      const name = tu.name.toLowerCase();
+      if (name === 'bash' || name === 'shell' || name.includes('terminal') || name === 'exec') {
+        const cmd =
+          tu.input && typeof tu.input === 'object'
+            ? String((tu.input as Record<string, unknown>)['command'] ?? '')
+            : '';
+        if (/\b(curl|wget|httpie|http\b)/i.test(cmd)) {
+          hits.add(`${name}: ${cmd.slice(0, 100)}`);
+        }
+      }
+    }
+  }
+  return [...hits];
+}
+
+interface BrowserFlags {
+  url?: string | undefined;
+  description: string;
+  model?: string | undefined;
+  background: boolean;
+  fresh: boolean;
+  force: boolean;
+  noGitCheck: boolean;
+  skipMcpCheck: boolean;
+  timeout: number;
+}
+
+function looksLikeUrl(token: string): boolean {
+  return (
+    /^https?:\/\//i.test(token) || /^localhost(:\d+)?(\/|$)/i.test(token) || /^\/\//.test(token)
+  );
+}
+
+function normaliseUrl(raw: string): string {
+  if (/^https?:\/\//i.test(raw)) return raw;
+  if (/^\/\//.test(raw)) return `http:${raw}`;
+  if (/^localhost(:\d+)?/i.test(raw)) return `http://${raw}`;
+  return raw;
+}
+
+function parseFlags(argv: string[]): BrowserFlags {
+  const { positional, flags } = parseArgv(argv, BOOLEAN_FLAGS);
+  const background = Boolean(flags['background']);
+  const fresh = Boolean(flags['fresh']);
+  const explicitForce = 'force' in flags ? Boolean(flags['force']) : undefined;
+  const force = explicitForce === undefined ? true : explicitForce;
+  const noGitCheck =
+    flags['gitCheck'] === false ||
+    flags['git-check'] === false ||
+    flags['no-git-check'] === true ||
+    flags['noGitCheck'] === true;
+  const skipMcpCheck =
+    flags['skip-mcp-check'] === true ||
+    flags['skipMcpCheck'] === true ||
+    flags['mcpCheck'] === false;
+  const timeoutRaw = flags['timeout'];
+  const timeout =
+    typeof timeoutRaw === 'number' ? timeoutRaw : timeoutRaw ? Number(timeoutRaw) : 1800;
+  const model = typeof flags['model'] === 'string' ? (flags['model'] as string) : undefined;
+
+  let url: string | undefined;
+  let descTokens: string[] = [];
+  if (positional.length > 0 && positional[0] && looksLikeUrl(positional[0])) {
+    url = normaliseUrl(positional[0]);
+    descTokens = positional.slice(1);
+  } else {
+    descTokens = positional.slice();
+  }
+  const description = descTokens.join(' ').trim();
+
+  return {
+    url,
+    description,
+    model,
+    background,
+    fresh,
+    force,
+    noGitCheck,
+    skipMcpCheck,
+    timeout,
+  };
+}
+
+async function preflightMcp(): Promise<{ ok: boolean; detail: string }> {
+  const mcps = await listConfiguredMcps();
+  if (mcps.length === 0) {
+    return {
+      ok: false,
+      detail: `No MCP servers configured in \`cursor-agent\`. Configure \`${MCP_NAME}\` in your Cursor MCP config (usually \`~/.cursor/mcp.json\`), for example: {"mcpServers":{"${MCP_NAME}":{"command":"npx","args":["-y","chrome-devtools-mcp@latest","--isolated"]}}} — then restart Cursor to pick up the change.`,
+    };
+  }
+  const match = mcps.find((m) => m.name === MCP_NAME);
+  if (!match) {
+    return {
+      ok: false,
+      detail: `\`${MCP_NAME}\` MCP is not configured. Configured MCPs: ${mcps
+        .map((m) => m.name)
+        .join(
+          ', ',
+        )}. Add \`${MCP_NAME}\` to your Cursor MCP config (usually \`~/.cursor/mcp.json\`) and restart Cursor.`,
+    };
+  }
+  return { ok: true, detail: match.status };
+}
+
+export async function main(rawArgv: string[]): Promise<number> {
+  const delimiterIdx = rawArgv.indexOf('--');
+  const firstHalf = delimiterIdx === -1 ? [] : rawArgv.slice(0, delimiterIdx);
+  const userRaw =
+    delimiterIdx === -1 ? rawArgv.join(' ') : rawArgv.slice(delimiterIdx + 1).join(' ');
+  const combined = [...firstHalf, ...collapseArguments(userRaw)];
+  const flags = parseFlags(combined);
+
+  if (flags.description.length === 0) {
+    process.stderr.write(
+      'Error: no test description. Usage: `/cursor:browser [<url>] <what to verify...>`. URL is optional — if omitted, Cursor discovers it from `list_pages` / package.json / common ports. Examples: `/cursor:browser http://localhost:3000 "login flow works"` or `/cursor:browser "check the home page loads without console errors"`.\n',
+    );
+    return 2;
+  }
+
+  const inGit = await isGitRepo(process.cwd());
+  if (!inGit && !flags.noGitCheck) {
+    process.stderr.write(
+      'Error: current directory is not a git repository. Pass --no-git-check to override.\n',
+    );
+    return 2;
+  }
+  const root = await repoRoot(process.cwd());
+
+  if (!flags.skipMcpCheck) {
+    const preflight = await preflightMcp();
+    if (!preflight.ok) {
+      process.stderr.write(`Error: ${preflight.detail}\n`);
+      process.stderr.write(
+        'Pass --skip-mcp-check to run anyway (e.g. if `cursor-agent mcp list` cannot reach its config).\n',
+      );
+      return 2;
+    }
+  }
+
+  const model = resolveModel(flags.model);
+  const prompt = buildBrowserPrompt(flags.url, flags.description);
+  const jobId = nanoid(10);
+  const logPath = rawLogPathFor(root, jobId);
+  ensureDir(jobsDir(root));
+  ensureDir(logsDir(root));
+  const urlLabel = flags.url ?? '(discover)';
+  createJob({
+    id: jobId,
+    repoPath: root,
+    prompt: `BROWSER: ${urlLabel} — ${flags.description}`,
+    model,
+  });
+  updateJob(root, jobId, { pid: process.pid });
+
+  process.stdout.write(
+    `Browser job \`${jobId}\` started against \`${urlLabel}\` (model \`${model}\`, MCP \`${MCP_NAME}\`).\n\n`,
+  );
+
+  let toolCalls = 0;
+  const result = await runHeadless({
+    prompt,
+    model,
+    cloud: false,
+    force: flags.force,
+    approveMcps: true,
+    timeoutSec: flags.timeout,
+    logPath,
+    onEvent: (ev) => {
+      for (const tu of extractToolUses(ev as unknown)) {
+        toolCalls += 1;
+        if (toolCalls <= 30) {
+          const short = tu.name.replace(/^mcp_chrome-devtools_/, 'cdt:');
+          process.stdout.write(`• ${short}\n`);
+        } else if (toolCalls === 31) {
+          process.stdout.write('• … (further tool calls omitted)\n');
+        }
+      }
+    },
+  });
+
+  const summary = summariseEvents(result.events);
+  const chatId = extractChatId(result.events);
+  const eventsAsRec = result.events as unknown as Array<Record<string, unknown>>;
+  const mcpUsed = usedBrowserMcp(eventsAsRec);
+  const httpFallbacks = usedBannedHttpClient(eventsAsRec);
+  const hadBrowserTools = toolCalls > 0;
+
+  let status: 'done' | 'failed' = result.exitCode === 0 && summary.success ? 'done' : 'failed';
+  const warnings: string[] = [];
+
+  if (!mcpUsed && hadBrowserTools) {
+    status = 'failed';
+    warnings.push(
+      `The run never called the \`${MCP_NAME}\` MCP. Browser verification requires real-browser tools — this result is NOT valid. Approve the \`${MCP_NAME}\` MCP in Cursor (usually needs a Cursor restart after editing \`~/.cursor/mcp.json\`) and re-run.`,
+    );
+  }
+  if (httpFallbacks.length > 0) {
+    status = 'failed';
+    warnings.push(
+      `The run fell back to a raw HTTP client instead of using the MCP. Banned calls detected:\n  - ${httpFallbacks.join('\n  - ')}\nA curl/wget/fetch check is not a browser test. Re-run after fixing the MCP.`,
+    );
+  }
+  if (!hadBrowserTools && result.exitCode === 0) {
+    warnings.push(
+      'The run completed but issued no tool calls at all — likely the prompt was interpreted as a question rather than a test. Re-run with a more concrete verification instruction.',
+    );
+  }
+
+  updateJob(root, jobId, {
+    status,
+    exitCode: result.exitCode,
+    finishedAt: new Date().toISOString(),
+    summary:
+      warnings.length > 0
+        ? `${summary.summary}\n\n[plugin post-flight]\n${warnings.join('\n\n')}`
+        : summary.summary,
+    filesTouched: summary.filesTouched,
+    ...(chatId ? { cursorChatId: chatId } : {}),
+  });
+
+  process.stdout.write('\n---\n');
+  process.stdout.write(`**Status:** ${status}\n`);
+  if (summary.summary) {
+    process.stdout.write('\n**Report:**\n\n');
+    process.stdout.write(summary.summary.trim() + '\n');
+  }
+  if (warnings.length > 0) {
+    process.stdout.write('\n**⚠ Post-flight warnings:**\n\n');
+    for (const w of warnings) process.stdout.write(`- ${w}\n`);
+  }
+  if (chatId) {
+    process.stdout.write(
+      `\n**Cursor chat id:** \`${chatId}\` — follow up with \`/cursor:resume\` or \`cursor-agent --resume=${chatId}\`.\n`,
+    );
+  }
+  process.stdout.write(`\nRun \`/cursor:status ${jobId}\` for the full record.\n`);
+  // Always return Cursor's own exit code. A post-flight warning is metadata —
+  // the report itself is what the user wants to see, so we never flip a
+  // successful shell exit into a failure just because the check is advisory.
+  return result.exitCode;
+}
+
+const invokedAsScript = (() => {
+  try {
+    return process.argv[1] === fileURLToPath(import.meta.url);
+  } catch {
+    return false;
+  }
+})();
+
+if (invokedAsScript) {
+  main(process.argv.slice(2))
+    .then((code) => process.exit(code))
+    .catch((err) => {
+      process.stderr.write(
+        `browser failed: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}\n`,
+      );
+      process.exit(1);
+    });
+}

--- a/plugins/cursor/scripts/cancel.ts
+++ b/plugins/cursor/scripts/cancel.ts
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+import { fileURLToPath } from 'node:url';
+import { collapseArguments, parseArgv } from './lib/argv.js';
+import { repoRoot } from './lib/git.js';
+import { cancelJob, findRunningJobs } from './lib/jobs.js';
+
+export async function main(rawArgv: string[]): Promise<number> {
+  const delimiterIdx = rawArgv.indexOf('--');
+  const firstHalf = delimiterIdx === -1 ? [] : rawArgv.slice(0, delimiterIdx);
+  const userRaw =
+    delimiterIdx === -1 ? rawArgv.join(' ') : rawArgv.slice(delimiterIdx + 1).join(' ');
+  const combined = [...firstHalf, ...collapseArguments(userRaw)];
+  const { positional } = parseArgv(combined);
+  const root = await repoRoot(process.cwd());
+
+  let id = positional[0];
+  if (!id) {
+    const running = findRunningJobs(root);
+    if (running.length === 0) {
+      process.stdout.write('No running Cursor jobs to cancel.\n');
+      return 0;
+    }
+    if (running.length > 1) {
+      process.stderr.write(
+        `Multiple running jobs (${running.length}). Pass an explicit id, e.g. \`/cursor:cancel ${running[0]?.id}\`.\n`,
+      );
+      return 2;
+    }
+    id = running[0]?.id;
+  }
+  if (!id) {
+    process.stderr.write('No job id resolved.\n');
+    return 2;
+  }
+
+  const updated = await cancelJob(root, id);
+  if (!updated) {
+    process.stderr.write(`No job \`${id}\` found for this repository.\n`);
+    return 1;
+  }
+  process.stdout.write(`Job \`${updated.id}\` marked as ${updated.status}.\n`);
+  return 0;
+}
+
+const invokedAsScript = (() => {
+  try {
+    return process.argv[1] === fileURLToPath(import.meta.url);
+  } catch {
+    return false;
+  }
+})();
+
+if (invokedAsScript) {
+  main(process.argv.slice(2))
+    .then((code) => process.exit(code))
+    .catch((err) => {
+      process.stderr.write(`cancel failed: ${err instanceof Error ? err.message : String(err)}\n`);
+      process.exit(1);
+    });
+}

--- a/plugins/cursor/scripts/delegate.ts
+++ b/plugins/cursor/scripts/delegate.ts
@@ -1,0 +1,313 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+import { openSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { nanoid } from 'nanoid';
+import { collapseArguments, parseArgv } from './lib/argv.js';
+import { resolveModel, runHeadless } from './lib/cursor.js';
+import { isGitRepo, repoRoot } from './lib/git.js';
+import {
+  createJob,
+  pruneOlderThanDays,
+  rawLogPath as rawLogPathFor,
+  updateJob,
+} from './lib/jobs.js';
+import { ensureDir, jobsDir, logsDir } from './lib/paths.js';
+import { extractChatId, summariseEvents } from './lib/parse.js';
+
+const BOOLEAN_FLAGS = ['background', 'wait', 'fresh', 'force', 'cloud', 'git-check', 'help'];
+
+interface DelegateFlags {
+  positional: string[];
+  model?: string | undefined;
+  background: boolean;
+  wait: boolean;
+  fresh: boolean;
+  resume?: string | boolean | undefined;
+  force: boolean;
+  cloud: boolean;
+  timeout: number;
+  noGitCheck: boolean;
+  worker?: string | undefined;
+}
+
+function parseFlags(argv: string[]): DelegateFlags {
+  const { positional, flags } = parseArgv(argv, BOOLEAN_FLAGS);
+  const background = Boolean(flags['background']);
+  const fresh = Boolean(flags['fresh']);
+  const cloud = Boolean(flags['cloud']);
+  const noGitCheck =
+    flags['gitCheck'] === false ||
+    flags['git-check'] === false ||
+    flags['no-git-check'] === true ||
+    flags['noGitCheck'] === true;
+  const explicitForceFlag = 'force' in flags ? Boolean(flags['force']) : undefined;
+  const force = explicitForceFlag === undefined ? true : explicitForceFlag;
+  const wait = 'wait' in flags ? Boolean(flags['wait']) : !background;
+  const timeoutRaw = flags['timeout'];
+  const timeout =
+    typeof timeoutRaw === 'number' ? timeoutRaw : timeoutRaw ? Number(timeoutRaw) : 1800;
+  const resume = flags['resume'] as string | boolean | undefined;
+  const model = typeof flags['model'] === 'string' ? (flags['model'] as string) : undefined;
+  const worker = typeof flags['worker'] === 'string' ? (flags['worker'] as string) : undefined;
+  return {
+    positional,
+    model,
+    background,
+    wait,
+    fresh,
+    resume,
+    force,
+    cloud,
+    timeout,
+    noGitCheck,
+    worker,
+  };
+}
+
+function isResumeRequested(resume: string | boolean | undefined, fresh: boolean): boolean {
+  if (fresh) return false;
+  if (resume === undefined) return false;
+  if (typeof resume === 'boolean') return resume;
+  return resume.trim().length >= 0;
+}
+
+function resumeChatId(resume: string | boolean | undefined): string | undefined {
+  if (
+    typeof resume === 'string' &&
+    resume.trim().length > 0 &&
+    resume.trim().toLowerCase() !== 'true'
+  ) {
+    return resume.trim();
+  }
+  return undefined;
+}
+
+async function foreground(
+  flags: DelegateFlags,
+  prompt: string,
+  jobId: string,
+  root: string,
+): Promise<number> {
+  const model = resolveModel(flags.model);
+  const logPath = rawLogPathFor(root, jobId);
+  ensureDir(jobsDir(root));
+  ensureDir(logsDir(root));
+  createJob({
+    id: jobId,
+    repoPath: root,
+    prompt,
+    model,
+    cloud: flags.cloud,
+  });
+  updateJob(root, jobId, { pid: process.pid });
+
+  const resume = isResumeRequested(flags.resume, flags.fresh);
+  const resumeId = resume ? resumeChatId(flags.resume) : undefined;
+
+  process.stdout.write(`Job \`${jobId}\` started on model \`${model}\` (foreground).\n\n`);
+
+  let toolCalls = 0;
+  const result = await runHeadless({
+    prompt,
+    model,
+    resumeChatId: resumeId,
+    resumeLatest: resume && !resumeId,
+    cloud: flags.cloud,
+    force: flags.force,
+    timeoutSec: flags.timeout,
+    logPath,
+    onEvent: (ev) => {
+      const type = ev['type'];
+      if (type === 'tool_use' || type === 'tool_call' || type === 'tool') {
+        toolCalls += 1;
+        if (toolCalls <= 20) {
+          const name =
+            (typeof ev['name'] === 'string' && ev['name']) ||
+            (typeof ev['tool_name'] === 'string' && ev['tool_name']) ||
+            'tool';
+          process.stdout.write(`• ${String(name)}\n`);
+        } else if (toolCalls === 21) {
+          process.stdout.write('• … (further tool calls omitted)\n');
+        }
+      }
+    },
+  });
+
+  const summary = summariseEvents(result.events);
+  const chatId = extractChatId(result.events);
+  const status = result.exitCode === 0 && summary.success ? 'done' : 'failed';
+
+  updateJob(root, jobId, {
+    status,
+    exitCode: result.exitCode,
+    finishedAt: new Date().toISOString(),
+    summary: summary.summary,
+    filesTouched: summary.filesTouched,
+    ...(chatId ? { cursorChatId: chatId } : {}),
+  });
+
+  process.stdout.write('\n---\n');
+  process.stdout.write(`**Status:** ${status}\n`);
+  if (summary.filesTouched.length > 0) {
+    process.stdout.write('**Files touched:**\n');
+    for (const f of summary.filesTouched) process.stdout.write(`- ${f}\n`);
+  }
+  if (summary.summary) {
+    process.stdout.write('\n**Summary:**\n\n');
+    process.stdout.write(summary.summary.trim() + '\n');
+  }
+  if (chatId) {
+    process.stdout.write(
+      `\n**Cursor chat id:** \`${chatId}\` — resume with \`cursor-agent --resume=${chatId}\`.\n`,
+    );
+  }
+  process.stdout.write(`\nRun \`/cursor:status ${jobId}\` for the full record.\n`);
+  return result.exitCode;
+}
+
+function spawnBackground(jobId: string, argv: string[]): number {
+  const selfPath = fileURLToPath(import.meta.url);
+  const logPath = rawLogPathFor(process.cwd(), jobId);
+  ensureDir(logsDir(process.cwd()));
+  const out = openSync(`${logPath}.stdout`, 'a');
+  const err = openSync(`${logPath}.stderr`, 'a');
+  const child = spawn(process.execPath, [selfPath, '--worker', jobId, ...argv], {
+    detached: true,
+    stdio: ['ignore', out, err],
+    env: { ...process.env, CURSOR_PLUGIN_CC_WORKER: '1' },
+  });
+  child.unref();
+  return child.pid ?? -1;
+}
+
+async function runWorker(jobId: string, flags: DelegateFlags, prompt: string, root: string) {
+  const model = resolveModel(flags.model);
+  const logPath = rawLogPathFor(root, jobId);
+  updateJob(root, jobId, { pid: process.pid, model });
+  const resume = isResumeRequested(flags.resume, flags.fresh);
+  const resumeId = resume ? resumeChatId(flags.resume) : undefined;
+  const result = await runHeadless({
+    prompt,
+    model,
+    resumeChatId: resumeId,
+    resumeLatest: resume && !resumeId,
+    cloud: flags.cloud,
+    force: flags.force,
+    timeoutSec: flags.timeout,
+    logPath,
+    onEvent: (ev) => {
+      const chatId = ev['chat_id'] ?? ev['chatId'] ?? ev['session_id'] ?? ev['sessionId'];
+      if (typeof chatId === 'string' && chatId.length > 0) {
+        try {
+          updateJob(root, jobId, { cursorChatId: chatId });
+        } catch {
+          /* noop */
+        }
+      }
+    },
+  });
+  const summary = summariseEvents(result.events);
+  const chatId = extractChatId(result.events);
+  const status = result.exitCode === 0 && summary.success ? 'done' : 'failed';
+  updateJob(root, jobId, {
+    status,
+    exitCode: result.exitCode,
+    finishedAt: new Date().toISOString(),
+    summary: summary.summary,
+    filesTouched: summary.filesTouched,
+    ...(chatId ? { cursorChatId: chatId } : {}),
+  });
+}
+
+export async function main(rawArgv: string[]): Promise<number> {
+  const delimiterIdx = rawArgv.indexOf('--');
+  const firstHalf = delimiterIdx === -1 ? [] : rawArgv.slice(0, delimiterIdx);
+  const userRaw =
+    delimiterIdx === -1 ? rawArgv.join(' ') : rawArgv.slice(delimiterIdx + 1).join(' ');
+  const combined = [...firstHalf, ...collapseArguments(userRaw)];
+  const flags = parseFlags(combined);
+
+  if (flags.worker) {
+    const prompt = flags.positional.join(' ').trim();
+    const root = process.env.CURSOR_PLUGIN_CC_REPO_ROOT ?? (await repoRoot(process.cwd()));
+    await runWorker(flags.worker, flags, prompt, root);
+    return 0;
+  }
+
+  const prompt = flags.positional.join(' ').trim();
+  if (!prompt && !isResumeRequested(flags.resume, flags.fresh)) {
+    process.stderr.write('Error: no task description provided.\n');
+    process.stderr.write('Usage: /cursor:delegate [flags] <task>\n');
+    return 2;
+  }
+
+  const inGit = await isGitRepo(process.cwd());
+  if (!inGit && !flags.noGitCheck) {
+    process.stderr.write(
+      'Error: current directory is not a git repository. Pass --no-git-check to override.\n',
+    );
+    return 2;
+  }
+  const root = await repoRoot(process.cwd());
+
+  pruneOlderThanDays(root, 30);
+
+  const jobId = nanoid(10);
+
+  if (flags.background) {
+    const model = resolveModel(flags.model);
+    createJob({
+      id: jobId,
+      repoPath: root,
+      prompt: prompt || '(resume)',
+      model,
+      background: true,
+      cloud: flags.cloud,
+    });
+    const forwardedArgs: string[] = [];
+    if (flags.model) forwardedArgs.push('--model', flags.model);
+    if (flags.fresh) forwardedArgs.push('--fresh');
+    if (flags.cloud) forwardedArgs.push('--cloud');
+    if (flags.resume !== undefined) {
+      if (typeof flags.resume === 'string') {
+        forwardedArgs.push(`--resume=${flags.resume}`);
+      } else if (flags.resume) {
+        forwardedArgs.push('--resume');
+      }
+    }
+    if (!flags.force) forwardedArgs.push('--no-force');
+    forwardedArgs.push('--timeout', String(flags.timeout));
+    if (prompt) {
+      forwardedArgs.push('--', prompt);
+    }
+    const pid = spawnBackground(jobId, [...forwardedArgs]);
+    updateJob(root, jobId, { pid });
+    process.stdout.write(
+      `Job \`${jobId}\` started in background (model \`${model}\`, pid ${pid}).\n`,
+    );
+    process.stdout.write(`Check progress with \`/cursor:status ${jobId}\`.\n`);
+    return 0;
+  }
+
+  return foreground(flags, prompt || '(resume)', jobId, root);
+}
+
+const invokedAsScript = (() => {
+  try {
+    return process.argv[1] === fileURLToPath(import.meta.url);
+  } catch {
+    return false;
+  }
+})();
+
+if (invokedAsScript) {
+  main(process.argv.slice(2))
+    .then((code) => process.exit(code))
+    .catch((err) => {
+      process.stderr.write(
+        `delegate failed: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}\n`,
+      );
+      process.exit(1);
+    });
+}

--- a/plugins/cursor/scripts/lib/argv.ts
+++ b/plugins/cursor/scripts/lib/argv.ts
@@ -1,0 +1,72 @@
+import yargsParser from 'yargs-parser';
+
+export interface ParsedArgs {
+  positional: string[];
+  flags: Record<string, unknown>;
+}
+
+export function splitArgString(arg: string): string[] {
+  const out: string[] = [];
+  let cur = '';
+  let quote: '"' | "'" | null = null;
+  let escape = false;
+  for (let i = 0; i < arg.length; i += 1) {
+    const ch = arg[i];
+    if (ch === undefined) continue;
+    if (escape) {
+      cur += ch;
+      escape = false;
+      continue;
+    }
+    if (ch === '\\') {
+      escape = true;
+      continue;
+    }
+    if (quote) {
+      if (ch === quote) {
+        quote = null;
+        continue;
+      }
+      cur += ch;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      continue;
+    }
+    if (ch === ' ' || ch === '\t' || ch === '\n') {
+      if (cur.length > 0) {
+        out.push(cur);
+        cur = '';
+      }
+      continue;
+    }
+    cur += ch;
+  }
+  if (cur.length > 0) out.push(cur);
+  return out;
+}
+
+export function parseArgv(argv: string[], booleans: string[] = []): ParsedArgs {
+  const parsed = yargsParser(argv, {
+    configuration: {
+      'populate--': false,
+      'halt-at-non-option': false,
+      'camel-case-expansion': true,
+      'boolean-negation': true,
+    },
+    boolean: booleans,
+  });
+  const flags: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(parsed)) {
+    if (k === '_') continue;
+    flags[k] = v;
+  }
+  const positional = (parsed._ ?? []).map((v) => String(v));
+  return { positional, flags };
+}
+
+export function collapseArguments(raw: string | undefined): string[] {
+  if (!raw || raw.trim().length === 0) return [];
+  return splitArgString(raw.trim());
+}

--- a/plugins/cursor/scripts/lib/cursor.ts
+++ b/plugins/cursor/scripts/lib/cursor.ts
@@ -1,0 +1,354 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import { createWriteStream } from 'node:fs';
+import { createInterface } from 'node:readline';
+import { execa } from 'execa';
+import { parseLine, type CursorEvent } from './parse.js';
+
+// Aliases map convenience names to concrete Cursor model ids as returned by
+// `cursor-agent --list-models`. Cursor rotates these over time — run
+// `/cursor:setup --print-models` to see the live list for your account.
+export const MODEL_ALIASES: Record<string, string> = {
+  // Composer (Cursor's own fast executor — default)
+  composer: 'composer-2-fast',
+  'composer-fast': 'composer-2-fast',
+  fast: 'composer-2-fast',
+  'composer-2-fast': 'composer-2-fast',
+  'composer-2': 'composer-2',
+  'composer-full': 'composer-2',
+  'composer-1.5': 'composer-1.5',
+  // Auto-routing
+  auto: 'auto',
+  // Claude Sonnet
+  sonnet: 'claude-4.6-sonnet-medium',
+  'sonnet-4.6': 'claude-4.6-sonnet-medium',
+  'sonnet-4.6-thinking': 'claude-4.6-sonnet-medium-thinking',
+  'sonnet-4.5': 'claude-4.5-sonnet',
+  'sonnet-4.5-thinking': 'claude-4.5-sonnet-thinking',
+  'sonnet-4': 'claude-4-sonnet',
+  // Claude Opus
+  opus: 'claude-opus-4-7-high',
+  'opus-4.7': 'claude-opus-4-7-high',
+  'opus-4.7-max': 'claude-opus-4-7-max',
+  'opus-4.7-thinking': 'claude-opus-4-7-thinking-high',
+  'opus-4.6': 'claude-4.6-opus-high',
+  // OpenAI Codex / GPT
+  gpt: 'gpt-5.3-codex',
+  codex: 'gpt-5.3-codex',
+  'gpt-5.3-codex': 'gpt-5.3-codex',
+  'gpt-5.3-codex-fast': 'gpt-5.3-codex-fast',
+  'gpt-5.3-codex-high': 'gpt-5.3-codex-high',
+  'gpt-5.2-codex': 'gpt-5.2-codex',
+  'gpt-5.2': 'gpt-5.2',
+  // Others
+  grok: 'grok-4-20',
+  'grok-thinking': 'grok-4-20-thinking',
+  gemini: 'gemini-3.1-pro',
+  'gemini-pro': 'gemini-3.1-pro',
+  'gemini-flash': 'gemini-3-flash',
+};
+
+// Cursor's own default is `composer-2-fast` (marked "(current, default)" by
+// `cursor-agent --list-models`). It is the fastest Composer variant — the
+// right choice for the delegate-and-move-on flow this plugin optimises for.
+export const DEFAULT_MODEL = 'composer-2-fast';
+
+export function resolveModel(input: string | undefined): string {
+  if (!input || input.trim() === '') return DEFAULT_MODEL;
+  const key = input.trim().toLowerCase();
+  return MODEL_ALIASES[key] ?? input.trim();
+}
+
+let cachedBin: string | null = null;
+
+export async function resolveBin(): Promise<string> {
+  if (cachedBin) return cachedBin;
+  const override = process.env.CURSOR_AGENT_BIN;
+  if (override && override.trim().length > 0) {
+    cachedBin = override;
+    return cachedBin;
+  }
+  for (const candidate of ['cursor-agent', 'agent']) {
+    try {
+      const res = await execa('which', [candidate], { reject: false });
+      if (res.exitCode === 0 && typeof res.stdout === 'string' && res.stdout.trim()) {
+        cachedBin = res.stdout.trim();
+        return cachedBin;
+      }
+    } catch {
+      continue;
+    }
+  }
+  throw new Error(
+    'cursor-agent not found on PATH. Install from https://cursor.com/install or run /cursor:setup.',
+  );
+}
+
+export interface DelegateOpts {
+  prompt: string;
+  model: string;
+  resumeChatId?: string | undefined;
+  resumeLatest?: boolean;
+  cloud?: boolean;
+  force?: boolean;
+  approveMcps?: boolean;
+  cwd?: string;
+  timeoutSec?: number;
+  logPath: string;
+  onEvent?: (ev: CursorEvent) => void;
+  onRaw?: (line: string) => void;
+}
+
+export interface DelegateResult {
+  exitCode: number;
+  events: CursorEvent[];
+  child: ChildProcess;
+  killed: boolean;
+}
+
+export function buildArgs(opts: {
+  prompt: string;
+  model: string;
+  resumeChatId?: string | undefined;
+  resumeLatest?: boolean;
+  cloud?: boolean;
+  force?: boolean;
+  approveMcps?: boolean;
+}): string[] {
+  const args: string[] = ['-p', '--output-format', 'stream-json', '--trust', '--model', opts.model];
+  if (opts.force !== false) {
+    args.push('--force');
+  }
+  if (opts.approveMcps) {
+    args.push('--approve-mcps');
+  }
+  if (opts.cloud) {
+    args.push('--cloud');
+  }
+  if (opts.resumeChatId) {
+    args.push(`--resume=${opts.resumeChatId}`);
+  } else if (opts.resumeLatest) {
+    args.push('--resume');
+  }
+  args.push(opts.prompt);
+  return args;
+}
+
+export async function runHeadless(opts: DelegateOpts): Promise<DelegateResult> {
+  const bin = await resolveBin();
+  const args = buildArgs(opts);
+  const child = spawn(bin, args, {
+    cwd: opts.cwd ?? process.cwd(),
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: process.env,
+  });
+
+  const logStream = createWriteStream(opts.logPath, { flags: 'a' });
+  const events: CursorEvent[] = [];
+  let sawResult = false;
+  let killed = false;
+
+  if (!child.stdout || !child.stderr) {
+    throw new Error('cursor-agent spawn failed: stdout/stderr not attached');
+  }
+  const childStdout = child.stdout;
+  const childStderr = child.stderr;
+  const stdoutLines = createInterface({ input: childStdout, crlfDelay: Infinity });
+  stdoutLines.on('line', (line) => {
+    logStream.write(line + '\n');
+    if (opts.onRaw) opts.onRaw(line);
+    const ev = parseLine(line);
+    if (!ev) return;
+    events.push(ev);
+    if (opts.onEvent) opts.onEvent(ev);
+    if (ev['type'] === 'result') {
+      sawResult = true;
+      setTimeout(() => {
+        if (!child.killed && child.exitCode === null) {
+          killed = true;
+          try {
+            child.kill('SIGTERM');
+          } catch {
+            /* noop */
+          }
+          setTimeout(() => {
+            if (!child.killed && child.exitCode === null) {
+              try {
+                child.kill('SIGKILL');
+              } catch {
+                /* noop */
+              }
+            }
+          }, 5_000);
+        }
+      }, 5_000);
+    }
+  });
+
+  const stderrLines = createInterface({ input: childStderr, crlfDelay: Infinity });
+  stderrLines.on('line', (line) => {
+    logStream.write(`# stderr: ${line}\n`);
+  });
+
+  let timeoutHandle: NodeJS.Timeout | undefined;
+  if (typeof opts.timeoutSec === 'number' && opts.timeoutSec > 0) {
+    timeoutHandle = setTimeout(() => {
+      killed = true;
+      try {
+        child.kill('SIGTERM');
+      } catch {
+        /* noop */
+      }
+      setTimeout(() => {
+        if (!child.killed && child.exitCode === null) {
+          try {
+            child.kill('SIGKILL');
+          } catch {
+            /* noop */
+          }
+        }
+      }, 5_000);
+    }, opts.timeoutSec * 1_000);
+  }
+
+  const exitCode: number = await new Promise((resolve) => {
+    child.on('close', (code) => {
+      resolve(typeof code === 'number' ? code : sawResult ? 0 : 1);
+    });
+  });
+
+  if (timeoutHandle) clearTimeout(timeoutHandle);
+  await new Promise<void>((resolve) => logStream.end(() => resolve()));
+
+  return { exitCode, events, child, killed };
+}
+
+export async function authStatus(): Promise<{ loggedIn: boolean; detail: string }> {
+  try {
+    const bin = await resolveBin();
+    const res = await execa(bin, ['status'], { reject: false, timeout: 5_000 });
+    const text = `${res.stdout ?? ''}\n${res.stderr ?? ''}`.toLowerCase();
+    const loggedIn =
+      res.exitCode === 0 &&
+      (text.includes('logged in') || text.includes('authenticated') || text.includes('signed in'));
+    return { loggedIn, detail: `${res.stdout ?? ''}${res.stderr ? `\n${res.stderr}` : ''}`.trim() };
+  } catch (err) {
+    return { loggedIn: false, detail: String(err) };
+  }
+}
+
+export interface McpEntry {
+  name: string;
+  status: string;
+  loaded: boolean;
+}
+
+export async function listConfiguredMcps(): Promise<McpEntry[]> {
+  try {
+    const bin = await resolveBin();
+    const res = await execa(bin, ['mcp', 'list'], { reject: false, timeout: 5_000 });
+    if (res.exitCode !== 0) return [];
+    const out: McpEntry[] = [];
+    // Strip ANSI color/cursor control codes — cursor-agent writes them even in pipe mode.
+    // eslint-disable-next-line no-control-regex
+    const text = String(res.stdout ?? '').replace(/\x1b\[[0-9;]*[A-Za-z]/g, '');
+    for (const raw of text.split('\n')) {
+      const line = raw.trim();
+      if (!line || line.startsWith('Loading')) continue;
+      const match = line.match(/^([^:\s]+):\s*(.+)$/);
+      if (!match) continue;
+      const name = match[1]!;
+      const status = match[2]!.trim();
+      const lower = status.toLowerCase();
+      const loaded = lower.startsWith('loaded') || lower === 'ok' || lower.includes('approved');
+      out.push({ name, status, loaded });
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}
+
+export async function listModels(): Promise<string[]> {
+  try {
+    const bin = await resolveBin();
+    const res = await execa(bin, ['--list-models'], { reject: false, timeout: 10_000 });
+    if (res.exitCode !== 0) {
+      const fallback = await execa(bin, ['models'], { reject: false, timeout: 10_000 });
+      return (fallback.stdout ?? '')
+        .split('\n')
+        .map((l) => l.trim())
+        .filter(Boolean);
+    }
+    return (res.stdout ?? '')
+      .split('\n')
+      .map((l) => l.trim())
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+export interface SessionSummary {
+  id: string;
+  summary?: string;
+  updatedAt?: string;
+}
+
+export async function listSessions(cwd: string = process.cwd()): Promise<SessionSummary[]> {
+  try {
+    const bin = await resolveBin();
+    const res = await execa(bin, ['ls', '--output-format', 'json'], {
+      cwd,
+      reject: false,
+      timeout: 5_000,
+    });
+    if (res.exitCode !== 0 || !res.stdout) return [];
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(res.stdout);
+    } catch {
+      return [];
+    }
+    if (!Array.isArray(parsed)) return [];
+    const out: SessionSummary[] = [];
+    for (const row of parsed) {
+      if (!row || typeof row !== 'object') continue;
+      const rec = row as Record<string, unknown>;
+      const id =
+        (typeof rec['id'] === 'string' && rec['id']) ||
+        (typeof rec['chat_id'] === 'string' && rec['chat_id']) ||
+        (typeof rec['chatId'] === 'string' && rec['chatId']);
+      if (!id) continue;
+      const summary =
+        typeof rec['summary'] === 'string'
+          ? (rec['summary'] as string)
+          : typeof rec['title'] === 'string'
+            ? (rec['title'] as string)
+            : undefined;
+      const updatedAt =
+        typeof rec['updated_at'] === 'string'
+          ? (rec['updated_at'] as string)
+          : typeof rec['updatedAt'] === 'string'
+            ? (rec['updatedAt'] as string)
+            : undefined;
+      const entry: SessionSummary = { id: id as string };
+      if (summary !== undefined) entry.summary = summary;
+      if (updatedAt !== undefined) entry.updatedAt = updatedAt;
+      out.push(entry);
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}
+
+export function maskSecrets(input: string): string {
+  let out = input;
+  for (const [name, value] of Object.entries(process.env)) {
+    if (!value || value.length < 4) continue;
+    if (/KEY|TOKEN|SECRET|PASSWORD/.test(name)) {
+      out = out.split(value).join('***');
+    }
+  }
+  return out;
+}

--- a/plugins/cursor/scripts/lib/git.ts
+++ b/plugins/cursor/scripts/lib/git.ts
@@ -1,0 +1,28 @@
+import { execa } from 'execa';
+
+export async function isGitRepo(cwd: string = process.cwd()): Promise<boolean> {
+  try {
+    const res = await execa('git', ['rev-parse', '--is-inside-work-tree'], {
+      cwd,
+      reject: false,
+      timeout: 3_000,
+    });
+    return res.exitCode === 0 && String(res.stdout ?? '').trim() === 'true';
+  } catch {
+    return false;
+  }
+}
+
+export async function repoRoot(cwd: string = process.cwd()): Promise<string> {
+  try {
+    const res = await execa('git', ['rev-parse', '--show-toplevel'], {
+      cwd,
+      reject: false,
+      timeout: 3_000,
+    });
+    if (res.exitCode === 0) return String(res.stdout ?? '').trim() || cwd;
+  } catch {
+    /* noop */
+  }
+  return cwd;
+}

--- a/plugins/cursor/scripts/lib/jobs.ts
+++ b/plugins/cursor/scripts/lib/jobs.ts
@@ -1,0 +1,201 @@
+import {
+  existsSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { z } from 'zod';
+import { ensureDir, jobsDir, logsDir } from './paths.js';
+
+export const JobStatus = z.enum(['running', 'done', 'failed', 'cancelled']);
+export type JobStatus = z.infer<typeof JobStatus>;
+
+export const JobRecord = z.object({
+  id: z.string().min(1),
+  repoPath: z.string(),
+  prompt: z.string(),
+  model: z.string(),
+  cursorChatId: z.string().optional(),
+  pid: z.number().int().positive().optional(),
+  status: JobStatus,
+  exitCode: z.number().int().optional(),
+  startedAt: z.string(),
+  finishedAt: z.string().optional(),
+  rawLogPath: z.string(),
+  summary: z.string().optional(),
+  filesTouched: z.array(z.string()).optional(),
+  background: z.boolean().optional(),
+  cloud: z.boolean().optional(),
+});
+export type JobRecord = z.infer<typeof JobRecord>;
+
+export interface CreateJobInit {
+  id: string;
+  repoPath: string;
+  prompt: string;
+  model: string;
+  background?: boolean;
+  cloud?: boolean;
+}
+
+export function jobFilePath(repoPath: string, id: string): string {
+  return join(jobsDir(repoPath), `${id}.json`);
+}
+
+export function rawLogPath(repoPath: string, id: string): string {
+  return join(logsDir(repoPath), `${id}.ndjson`);
+}
+
+function atomicWrite(target: string, data: string): void {
+  const tmp = `${target}.tmp-${process.pid}-${Date.now()}`;
+  writeFileSync(tmp, data, 'utf8');
+  renameSync(tmp, target);
+}
+
+export function createJob(init: CreateJobInit): JobRecord {
+  ensureDir(jobsDir(init.repoPath));
+  ensureDir(logsDir(init.repoPath));
+  const record: JobRecord = {
+    id: init.id,
+    repoPath: init.repoPath,
+    prompt: init.prompt,
+    model: init.model,
+    status: 'running',
+    startedAt: new Date().toISOString(),
+    rawLogPath: rawLogPath(init.repoPath, init.id),
+    ...(init.background ? { background: true } : {}),
+    ...(init.cloud ? { cloud: true } : {}),
+  };
+  atomicWrite(jobFilePath(init.repoPath, init.id), JSON.stringify(record, null, 2));
+  return record;
+}
+
+export function readJob(repoPath: string, id: string): JobRecord | null {
+  const file = jobFilePath(repoPath, id);
+  if (!existsSync(file)) return null;
+  const raw = readFileSync(file, 'utf8');
+  return JobRecord.parse(JSON.parse(raw));
+}
+
+export function updateJob(
+  repoPath: string,
+  id: string,
+  patch: Partial<JobRecord>,
+): JobRecord | null {
+  const existing = readJob(repoPath, id);
+  if (!existing) return null;
+  const merged: JobRecord = JobRecord.parse({ ...existing, ...patch });
+  atomicWrite(jobFilePath(repoPath, id), JSON.stringify(merged, null, 2));
+  return merged;
+}
+
+export interface ListOpts {
+  limit?: number;
+  status?: JobStatus;
+}
+
+export function listJobs(repoPath: string, opts: ListOpts = {}): JobRecord[] {
+  const dir = jobsDir(repoPath);
+  if (!existsSync(dir)) return [];
+  const files = readdirSync(dir).filter((f) => f.endsWith('.json') && !f.endsWith('.tmp'));
+  const records: JobRecord[] = [];
+  for (const f of files) {
+    try {
+      const raw = readFileSync(join(dir, f), 'utf8');
+      records.push(JobRecord.parse(JSON.parse(raw)));
+    } catch {
+      continue;
+    }
+  }
+  records.sort((a, b) => (a.startedAt < b.startedAt ? 1 : -1));
+  const filtered = opts.status ? records.filter((r) => r.status === opts.status) : records;
+  return typeof opts.limit === 'number' ? filtered.slice(0, opts.limit) : filtered;
+}
+
+export function pruneOlderThanDays(repoPath: string, days = 30): number {
+  const dir = jobsDir(repoPath);
+  if (!existsSync(dir)) return 0;
+  const cutoff = Date.now() - days * 24 * 60 * 60 * 1000;
+  let removed = 0;
+  for (const f of readdirSync(dir)) {
+    const p = join(dir, f);
+    try {
+      const st = statSync(p);
+      if (st.isFile() && st.mtimeMs < cutoff) {
+        unlinkSync(p);
+        removed += 1;
+      }
+    } catch {
+      continue;
+    }
+  }
+  const lDir = logsDir(repoPath);
+  if (existsSync(lDir)) {
+    for (const f of readdirSync(lDir)) {
+      const p = join(lDir, f);
+      try {
+        const st = statSync(p);
+        if (st.isFile() && st.mtimeMs < cutoff) {
+          unlinkSync(p);
+        }
+      } catch {
+        continue;
+      }
+    }
+  }
+  return removed;
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function cancelJob(
+  repoPath: string,
+  id: string,
+  graceMs = 5_000,
+): Promise<JobRecord | null> {
+  const job = readJob(repoPath, id);
+  if (!job) return null;
+  if (job.status !== 'running') return job;
+  if (typeof job.pid === 'number' && isProcessAlive(job.pid)) {
+    try {
+      process.kill(job.pid, 'SIGTERM');
+    } catch {
+      // ignore; process may have exited
+    }
+    const deadline = Date.now() + graceMs;
+    while (Date.now() < deadline && isProcessAlive(job.pid)) {
+      await new Promise((r) => setTimeout(r, 200));
+    }
+    if (isProcessAlive(job.pid)) {
+      try {
+        process.kill(job.pid, 'SIGKILL');
+      } catch {
+        // ignore
+      }
+    }
+  }
+  return updateJob(repoPath, id, {
+    status: 'cancelled',
+    finishedAt: new Date().toISOString(),
+  });
+}
+
+export function findRunningJobs(repoPath: string): JobRecord[] {
+  return listJobs(repoPath).filter((j) => j.status === 'running');
+}
+
+export function mostRecentFinishedJob(repoPath: string): JobRecord | null {
+  const jobs = listJobs(repoPath).filter((j) => j.status !== 'running');
+  return jobs[0] ?? null;
+}

--- a/plugins/cursor/scripts/lib/parse.ts
+++ b/plugins/cursor/scripts/lib/parse.ts
@@ -1,0 +1,165 @@
+import { z } from 'zod';
+
+const BaseEvent = z
+  .object({
+    type: z.string().optional(),
+    subtype: z.string().optional(),
+    session_id: z.string().optional(),
+    sessionId: z.string().optional(),
+    chat_id: z.string().optional(),
+    chatId: z.string().optional(),
+  })
+  .passthrough();
+
+export type CursorEvent = z.infer<typeof BaseEvent>;
+
+export function parseLine(line: string): CursorEvent | null {
+  const trimmed = line.trim();
+  if (trimmed.length === 0) return null;
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (parsed == null || typeof parsed !== 'object') return null;
+    return BaseEvent.parse(parsed);
+  } catch {
+    return null;
+  }
+}
+
+const CHAT_ID_KEYS = ['chat_id', 'chatId', 'session_id', 'sessionId'] as const;
+
+function dig(obj: unknown, keys: readonly string[]): string | undefined {
+  if (obj == null || typeof obj !== 'object') return undefined;
+  const rec = obj as Record<string, unknown>;
+  for (const k of keys) {
+    const v = rec[k];
+    if (typeof v === 'string' && v.length > 0) return v;
+  }
+  for (const v of Object.values(rec)) {
+    const found = dig(v, keys);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+export function extractChatId(events: CursorEvent[]): string | undefined {
+  for (const ev of events) {
+    const id = dig(ev, CHAT_ID_KEYS);
+    if (id) return id;
+  }
+  return undefined;
+}
+
+const WRITE_TOOL_HINTS = [
+  'write',
+  'edit',
+  'str_replace',
+  'create_file',
+  'patch',
+  'apply_patch',
+  'file_write',
+];
+
+function looksLikeFileWrite(name: unknown): boolean {
+  if (typeof name !== 'string') return false;
+  const lower = name.toLowerCase();
+  return WRITE_TOOL_HINTS.some((h) => lower.includes(h));
+}
+
+function pickString(obj: unknown, keys: readonly string[]): string | undefined {
+  if (obj == null || typeof obj !== 'object') return undefined;
+  const rec = obj as Record<string, unknown>;
+  for (const k of keys) {
+    const v = rec[k];
+    if (typeof v === 'string' && v.length > 0) return v;
+  }
+  return undefined;
+}
+
+export interface Summary {
+  summary: string;
+  filesTouched: string[];
+  exitReason: string;
+  success: boolean;
+}
+
+function* walkToolUses(node: unknown): Iterable<{ name: string; input: unknown }> {
+  if (node == null || typeof node !== 'object') return;
+  if (Array.isArray(node)) {
+    for (const item of node) yield* walkToolUses(item);
+    return;
+  }
+  const obj = node as Record<string, unknown>;
+  const type = obj['type'];
+  const name = typeof obj['name'] === 'string' ? (obj['name'] as string) : undefined;
+  if ((type === 'tool_use' || type === 'tool_call') && name) {
+    yield {
+      name,
+      input: obj['input'] ?? obj['arguments'] ?? obj['params'] ?? obj['tool_input'],
+    };
+  }
+  for (const v of Object.values(obj)) yield* walkToolUses(v);
+}
+
+export function summariseEvents(events: CursorEvent[]): Summary {
+  const files = new Set<string>();
+  let finalText: string | undefined;
+  let success = true;
+  let exitReason = 'completed';
+
+  for (const ev of events) {
+    for (const tu of walkToolUses(ev)) {
+      if (!looksLikeFileWrite(tu.name)) continue;
+      const path = pickString(tu.input, [
+        'path',
+        'file_path',
+        'filename',
+        'file',
+        'target',
+        'target_file',
+      ]);
+      if (path) files.add(path);
+    }
+    const type = ev['type'];
+    if (type === 'result') {
+      const text =
+        pickString(ev, ['result', 'text', 'message', 'content']) ??
+        pickString(ev['message'], ['text', 'content']);
+      if (text) finalText = text;
+      const subtype = typeof ev['subtype'] === 'string' ? (ev['subtype'] as string) : undefined;
+      const isError = ev['is_error'] === true || ev['error'] != null;
+      if (subtype && subtype !== 'success') {
+        exitReason = subtype;
+        if (subtype.includes('error') || subtype.includes('fail')) success = false;
+      }
+      if (isError) {
+        success = false;
+        exitReason = 'error';
+      }
+    }
+  }
+
+  if (!finalText) {
+    for (let i = events.length - 1; i >= 0; i -= 1) {
+      const ev = events[i];
+      if (!ev) continue;
+      const type = ev['type'];
+      if (type === 'assistant' || type === 'message') {
+        const text =
+          pickString(ev, ['text', 'content', 'message']) ??
+          pickString(ev['message'], ['text', 'content']);
+        if (text) {
+          finalText = text;
+          break;
+        }
+      }
+    }
+  }
+
+  const summary = finalText ?? '(no final message captured)';
+  return {
+    summary: summary.slice(0, 4000),
+    filesTouched: [...files],
+    exitReason,
+    success,
+  };
+}

--- a/plugins/cursor/scripts/lib/paths.ts
+++ b/plugins/cursor/scripts/lib/paths.ts
@@ -1,0 +1,29 @@
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, realpathSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+export function pluginHome(): string {
+  const fromEnv = process.env.CURSOR_PLUGIN_CC_HOME;
+  if (fromEnv && fromEnv.trim().length > 0) {
+    return resolve(fromEnv);
+  }
+  return join(homedir(), '.cursor-plugin-cc');
+}
+
+export function repoHash(repoRoot: string): string {
+  const canonical = existsSync(repoRoot) ? realpathSync(repoRoot) : resolve(repoRoot);
+  return createHash('sha256').update(canonical).digest('hex').slice(0, 12);
+}
+
+export function jobsDir(repoRoot: string): string {
+  return join(pluginHome(), 'jobs', repoHash(repoRoot));
+}
+
+export function logsDir(repoRoot: string): string {
+  return join(jobsDir(repoRoot), 'logs');
+}
+
+export function ensureDir(dir: string): void {
+  mkdirSync(dir, { recursive: true });
+}

--- a/plugins/cursor/scripts/result.ts
+++ b/plugins/cursor/scripts/result.ts
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+import { fileURLToPath } from 'node:url';
+import { collapseArguments, parseArgv } from './lib/argv.js';
+import { repoRoot } from './lib/git.js';
+import { mostRecentFinishedJob, readJob, type JobRecord } from './lib/jobs.js';
+
+function render(job: JobRecord): string {
+  const lines: string[] = [];
+  lines.push(`### Result of job \`${job.id}\` — ${job.status}`);
+  lines.push('');
+  lines.push(`**Model:** ${job.model}`);
+  if (job.finishedAt) lines.push(`**Finished:** ${job.finishedAt}`);
+  if (typeof job.exitCode === 'number') lines.push(`**Exit code:** ${job.exitCode}`);
+  lines.push('');
+  lines.push(`**Prompt:** ${job.prompt}`);
+  if (job.filesTouched && job.filesTouched.length > 0) {
+    lines.push('');
+    lines.push('**Files touched:**');
+    for (const f of job.filesTouched) lines.push(`- ${f}`);
+  }
+  lines.push('');
+  lines.push('**Summary:**');
+  lines.push('');
+  lines.push((job.summary ?? '(no summary captured)').trim());
+  lines.push('');
+  if (job.cursorChatId) {
+    lines.push(`Resume: \`cursor-agent --resume=${job.cursorChatId}\``);
+  } else {
+    lines.push('Cursor chat id was not captured for this job.');
+  }
+  return lines.join('\n') + '\n';
+}
+
+export async function main(rawArgv: string[]): Promise<number> {
+  const delimiterIdx = rawArgv.indexOf('--');
+  const firstHalf = delimiterIdx === -1 ? [] : rawArgv.slice(0, delimiterIdx);
+  const userRaw =
+    delimiterIdx === -1 ? rawArgv.join(' ') : rawArgv.slice(delimiterIdx + 1).join(' ');
+  const combined = [...firstHalf, ...collapseArguments(userRaw)];
+  const { positional } = parseArgv(combined);
+  const root = await repoRoot(process.cwd());
+  const id = positional[0];
+
+  const job = id ? readJob(root, id) : mostRecentFinishedJob(root);
+  if (!job) {
+    process.stderr.write(
+      id
+        ? `No job \`${id}\` found for this repository.\n`
+        : 'No finished Cursor jobs tracked for this repository yet.\n',
+    );
+    return 1;
+  }
+  if (job.status === 'running') {
+    process.stdout.write(
+      `Job \`${job.id}\` is still running. Use \`/cursor:status ${job.id}\` to monitor it.\n`,
+    );
+    return 0;
+  }
+  process.stdout.write(render(job));
+  return 0;
+}
+
+const invokedAsScript = (() => {
+  try {
+    return process.argv[1] === fileURLToPath(import.meta.url);
+  } catch {
+    return false;
+  }
+})();
+
+if (invokedAsScript) {
+  main(process.argv.slice(2))
+    .then((code) => process.exit(code))
+    .catch((err) => {
+      process.stderr.write(`result failed: ${err instanceof Error ? err.message : String(err)}\n`);
+      process.exit(1);
+    });
+}

--- a/plugins/cursor/scripts/resume.ts
+++ b/plugins/cursor/scripts/resume.ts
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+import { fileURLToPath } from 'node:url';
+import { main as delegateMain } from './delegate.js';
+
+export async function main(rawArgv: string[]): Promise<number> {
+  const argv = rawArgv.slice();
+  const hasResume = argv.some((a) => a === '--resume' || a.startsWith('--resume='));
+  if (!hasResume) argv.unshift('--resume');
+  return delegateMain(argv);
+}
+
+const invokedAsScript = (() => {
+  try {
+    return process.argv[1] === fileURLToPath(import.meta.url);
+  } catch {
+    return false;
+  }
+})();
+
+if (invokedAsScript) {
+  main(process.argv.slice(2))
+    .then((code) => process.exit(code))
+    .catch((err) => {
+      process.stderr.write(`resume failed: ${err instanceof Error ? err.message : String(err)}\n`);
+      process.exit(1);
+    });
+}

--- a/plugins/cursor/scripts/sessions.ts
+++ b/plugins/cursor/scripts/sessions.ts
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+import { fileURLToPath } from 'node:url';
+import { listSessions } from './lib/cursor.js';
+import { repoRoot } from './lib/git.js';
+import { listJobs } from './lib/jobs.js';
+
+export async function main(): Promise<number> {
+  const root = await repoRoot(process.cwd());
+  const sessions = await listSessions(root);
+  if (sessions.length > 0) {
+    process.stdout.write('### Cursor sessions for this repository\n\n');
+    process.stdout.write('| Chat ID | Updated | Summary |\n| --- | --- | --- |\n');
+    for (const s of sessions) {
+      const updated = s.updatedAt ?? '—';
+      const summary = (s.summary ?? '').replace(/\s+/g, ' ').slice(0, 80);
+      process.stdout.write(`| \`${s.id}\` | ${updated} | ${summary} |\n`);
+    }
+    process.stdout.write('\nResume any of them with `cursor-agent --resume=<id>`.\n');
+    return 0;
+  }
+
+  process.stdout.write(
+    '`cursor-agent ls` returned no sessions (or timed out). Falling back to local job registry:\n\n',
+  );
+  const jobs = listJobs(root, { limit: 10 });
+  if (jobs.length === 0) {
+    process.stdout.write('No local jobs tracked for this repository yet.\n');
+    return 0;
+  }
+  process.stdout.write(
+    '| Job ID | Status | Cursor chat id | Prompt |\n| --- | --- | --- | --- |\n',
+  );
+  for (const j of jobs) {
+    const chat = j.cursorChatId ? `\`${j.cursorChatId}\`` : '—';
+    const prompt = j.prompt.replace(/\s+/g, ' ').slice(0, 60);
+    process.stdout.write(`| \`${j.id}\` | ${j.status} | ${chat} | ${prompt} |\n`);
+  }
+  return 0;
+}
+
+const invokedAsScript = (() => {
+  try {
+    return process.argv[1] === fileURLToPath(import.meta.url);
+  } catch {
+    return false;
+  }
+})();
+
+if (invokedAsScript) {
+  main()
+    .then((code) => process.exit(code))
+    .catch((err) => {
+      process.stderr.write(
+        `sessions failed: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      process.exit(1);
+    });
+}

--- a/plugins/cursor/scripts/setup.ts
+++ b/plugins/cursor/scripts/setup.ts
@@ -1,0 +1,207 @@
+#!/usr/bin/env node
+import { accessSync, constants as fsConstants, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execa } from 'execa';
+import { collapseArguments, parseArgv } from './lib/argv.js';
+import { authStatus, listConfiguredMcps, listModels, resolveBin } from './lib/cursor.js';
+import { ensureDir, jobsDir, pluginHome } from './lib/paths.js';
+
+function pluginRoot(): string {
+  const envRoot = process.env.CLAUDE_PLUGIN_ROOT;
+  if (envRoot && envRoot.trim()) return envRoot;
+  return fileURLToPath(new URL('..', import.meta.url));
+}
+
+function checkBuild(): { ok: boolean; detail: string } {
+  const dist = join(pluginRoot(), 'dist');
+  if (!existsSync(dist)) {
+    return {
+      ok: false,
+      detail: `compiled dist/ missing — run \`cd ${pluginRoot()} && npm install\` (runs the build automatically via npm prepare).`,
+    };
+  }
+  const entry = join(dist, 'setup.js');
+  if (!existsSync(entry)) {
+    return { ok: false, detail: `dist/ exists but setup.js is missing — run \`npm run build\`.` };
+  }
+  return { ok: true, detail: `compiled at ${dist}` };
+}
+
+function checkJobsDir(): { ok: boolean; detail: string } {
+  try {
+    const home = pluginHome();
+    ensureDir(home);
+    const repoDir = jobsDir(process.cwd());
+    ensureDir(repoDir);
+    accessSync(repoDir, fsConstants.W_OK);
+    return { ok: true, detail: repoDir };
+  } catch (err) {
+    return { ok: false, detail: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+function maskKey(value: string): string {
+  if (value.length <= 8) return '***';
+  return `${value.slice(0, 4)}…${value.slice(-4)}`;
+}
+
+async function doctor(): Promise<number> {
+  const lines: string[] = ['### /cursor:setup --doctor\n'];
+  const checks: Array<[string, { ok: boolean; detail: string }]> = [];
+
+  lines.push(`- Node: ${process.version}`);
+  lines.push(`- Platform: ${process.platform} (${process.arch})`);
+  lines.push(`- Plugin home: \`${pluginHome()}\``);
+
+  let bin = '';
+  try {
+    bin = await resolveBin();
+    checks.push(['cursor-agent binary', { ok: true, detail: bin }]);
+  } catch (err) {
+    checks.push([
+      'cursor-agent binary',
+      { ok: false, detail: err instanceof Error ? err.message : String(err) },
+    ]);
+  }
+
+  if (bin) {
+    try {
+      const ver = await execa(bin, ['--version'], { reject: false, timeout: 5_000 });
+      checks.push([
+        'cursor-agent version',
+        { ok: ver.exitCode === 0, detail: String(ver.stdout ?? ver.stderr ?? '').trim() },
+      ]);
+    } catch (err) {
+      checks.push(['cursor-agent version', { ok: false, detail: String(err) }]);
+    }
+    const auth = await authStatus();
+    checks.push([
+      'cursor-agent auth',
+      {
+        ok: auth.loggedIn,
+        detail: auth.loggedIn ? 'logged in' : `not logged in — run \`cursor-agent login\``,
+      },
+    ]);
+  }
+
+  const build = checkBuild();
+  checks.push(['compiled dist/', build]);
+
+  const jobs = checkJobsDir();
+  checks.push(['jobs directory writable', jobs]);
+
+  const apiKey = process.env.CURSOR_API_KEY;
+  checks.push([
+    'CURSOR_API_KEY',
+    { ok: true, detail: apiKey ? `set (${maskKey(apiKey)})` : 'not set (using local session)' },
+  ]);
+
+  lines.push('');
+  for (const [name, r] of checks) {
+    const icon = r.ok ? '✓' : '✗';
+    lines.push(`- ${icon} **${name}** — ${r.detail}`);
+  }
+
+  if (bin) {
+    const mcps = await listConfiguredMcps();
+    lines.push('');
+    lines.push('**Configured Cursor MCPs:**');
+    if (mcps.length === 0) {
+      lines.push('- (none configured — browser testing via `/cursor:browser` will refuse to run)');
+    } else {
+      for (const m of mcps) {
+        const icon = m.loaded ? '✓' : '•';
+        lines.push(`- ${icon} \`${m.name}\` — ${m.status}`);
+      }
+    }
+  }
+
+  const allOk = checks.every(([, r]) => r.ok || r.detail.includes('not set'));
+  lines.push('');
+  lines.push(allOk ? 'All checks passed.' : 'Some checks failed — see above.');
+  process.stdout.write(lines.join('\n') + '\n');
+  return allOk ? 0 : 1;
+}
+
+async function printModels(): Promise<number> {
+  process.stdout.write('### Cursor models (from your account)\n\n');
+  const models = await listModels();
+  if (models.length === 0) {
+    process.stdout.write(
+      'Could not fetch model list. Try `cursor-agent --list-models` directly or `cursor-agent models`.\n',
+    );
+    return 1;
+  }
+  for (const m of models) process.stdout.write(`- ${m}\n`);
+  return 0;
+}
+
+async function maybeInstall(): Promise<number> {
+  process.stdout.write(
+    'This will run: `curl https://cursor.com/install -fsS | bash`\n' +
+      'Aborting automatic execution — re-run the command above manually to install.\n',
+  );
+  return 0;
+}
+
+async function baseCheck(): Promise<number> {
+  const lines: string[] = ['### /cursor:setup\n'];
+  try {
+    const bin = await resolveBin();
+    lines.push(`- ✓ \`cursor-agent\` at \`${bin}\``);
+    const auth = await authStatus();
+    lines.push(
+      auth.loggedIn
+        ? '- ✓ Cursor CLI is logged in.'
+        : '- ✗ Cursor CLI is not logged in. Run `cursor-agent login` in a terminal.',
+    );
+    const build = checkBuild();
+    lines.push(build.ok ? `- ✓ ${build.detail}` : `- ✗ ${build.detail}`);
+    const jobs = checkJobsDir();
+    lines.push(jobs.ok ? `- ✓ jobs dir writable: \`${jobs.detail}\`` : `- ✗ ${jobs.detail}`);
+    lines.push('');
+    lines.push('Ready. Try `/cursor:delegate "write a short haiku about git"` to smoke-test.');
+    process.stdout.write(lines.join('\n') + '\n');
+    return 0;
+  } catch (err) {
+    lines.push(`- ✗ ${err instanceof Error ? err.message : String(err)}`);
+    lines.push('');
+    lines.push(
+      'Install Cursor CLI with: `curl https://cursor.com/install -fsS | bash`\n' +
+        'Then run `cursor-agent login` and re-run `/cursor:setup`.',
+    );
+    process.stdout.write(lines.join('\n') + '\n');
+    return 1;
+  }
+}
+
+export async function main(rawArgv: string[]): Promise<number> {
+  const delimiterIdx = rawArgv.indexOf('--');
+  const firstHalf = delimiterIdx === -1 ? [] : rawArgv.slice(0, delimiterIdx);
+  const userRaw =
+    delimiterIdx === -1 ? rawArgv.join(' ') : rawArgv.slice(delimiterIdx + 1).join(' ');
+  const combined = [...firstHalf, ...collapseArguments(userRaw)];
+  const { flags } = parseArgv(combined, ['doctor', 'print-models', 'printModels', 'install']);
+  if (flags['doctor']) return doctor();
+  if (flags['print-models'] || flags['printModels']) return printModels();
+  if (flags['install']) return maybeInstall();
+  return baseCheck();
+}
+
+const invokedAsScript = (() => {
+  try {
+    return process.argv[1] === fileURLToPath(import.meta.url);
+  } catch {
+    return false;
+  }
+})();
+
+if (invokedAsScript) {
+  main(process.argv.slice(2))
+    .then((code) => process.exit(code))
+    .catch((err) => {
+      process.stderr.write(`setup failed: ${err instanceof Error ? err.message : String(err)}\n`);
+      process.exit(1);
+    });
+}

--- a/plugins/cursor/scripts/status.ts
+++ b/plugins/cursor/scripts/status.ts
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+import { fileURLToPath } from 'node:url';
+import { collapseArguments, parseArgv } from './lib/argv.js';
+import { repoRoot } from './lib/git.js';
+import { listJobs, readJob, type JobRecord } from './lib/jobs.js';
+
+function age(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  if (!Number.isFinite(ms) || ms < 0) return '?';
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  if (h < 48) return `${h}h`;
+  return `${Math.floor(h / 24)}d`;
+}
+
+function truncate(s: string, n: number): string {
+  const clean = s.replace(/\s+/g, ' ').trim();
+  return clean.length > n ? `${clean.slice(0, n - 1)}…` : clean;
+}
+
+function renderTable(rows: JobRecord[]): string {
+  if (rows.length === 0) return 'No Cursor jobs tracked for this repository yet.\n';
+  const header = '| ID | Status | Model | Age | Prompt |';
+  const sep = '| --- | --- | --- | --- | --- |';
+  const body = rows
+    .map(
+      (r) =>
+        `| \`${r.id}\` | ${r.status} | ${r.model} | ${age(r.startedAt)} | ${truncate(
+          r.prompt,
+          60,
+        )} |`,
+    )
+    .join('\n');
+  return `${header}\n${sep}\n${body}\n`;
+}
+
+function renderDetail(r: JobRecord): string {
+  const lines: string[] = [];
+  lines.push(`### Job \`${r.id}\``);
+  lines.push('');
+  lines.push(`- **Status:** ${r.status}`);
+  lines.push(`- **Model:** ${r.model}`);
+  lines.push(`- **Started:** ${r.startedAt}`);
+  if (r.finishedAt) lines.push(`- **Finished:** ${r.finishedAt}`);
+  if (typeof r.exitCode === 'number') lines.push(`- **Exit code:** ${r.exitCode}`);
+  if (r.pid) lines.push(`- **PID:** ${r.pid}`);
+  if (r.cursorChatId) {
+    lines.push(`- **Cursor chat id:** \`${r.cursorChatId}\``);
+    lines.push(`  Resume: \`cursor-agent --resume=${r.cursorChatId}\``);
+  }
+  if (r.cloud) lines.push('- **Cloud:** yes');
+  if (r.background) lines.push('- **Background:** yes');
+  lines.push('');
+  lines.push(`**Prompt:** ${r.prompt}`);
+  if (r.filesTouched && r.filesTouched.length > 0) {
+    lines.push('');
+    lines.push('**Files touched:**');
+    for (const f of r.filesTouched) lines.push(`- ${f}`);
+  }
+  if (r.summary) {
+    lines.push('');
+    lines.push('**Summary:**');
+    lines.push('');
+    lines.push(r.summary.trim());
+  }
+  lines.push('');
+  lines.push(`**Raw log:** \`${r.rawLogPath}\``);
+  return lines.join('\n') + '\n';
+}
+
+export async function main(rawArgv: string[]): Promise<number> {
+  const delimiterIdx = rawArgv.indexOf('--');
+  const firstHalf = delimiterIdx === -1 ? [] : rawArgv.slice(0, delimiterIdx);
+  const userRaw =
+    delimiterIdx === -1 ? rawArgv.join(' ') : rawArgv.slice(delimiterIdx + 1).join(' ');
+  const combined = [...firstHalf, ...collapseArguments(userRaw)];
+  const { positional, flags } = parseArgv(combined, ['all']);
+  const root = await repoRoot(process.cwd());
+  const id = positional[0];
+
+  if (id) {
+    const job = readJob(root, id);
+    if (!job) {
+      process.stderr.write(`No job \`${id}\` found for this repository.\n`);
+      return 1;
+    }
+    process.stdout.write(renderDetail(job));
+    return 0;
+  }
+
+  const limit = flags['all'] ? undefined : 10;
+  const listOpts: { limit?: number } = {};
+  if (typeof limit === 'number') listOpts.limit = limit;
+  const rows = listJobs(root, listOpts);
+  process.stdout.write(renderTable(rows));
+  return 0;
+}
+
+const invokedAsScript = (() => {
+  try {
+    return process.argv[1] === fileURLToPath(import.meta.url);
+  } catch {
+    return false;
+  }
+})();
+
+if (invokedAsScript) {
+  main(process.argv.slice(2))
+    .then((code) => process.exit(code))
+    .catch((err) => {
+      process.stderr.write(`status failed: ${err instanceof Error ? err.message : String(err)}\n`);
+      process.exit(1);
+    });
+}

--- a/plugins/cursor/tests/argv.test.ts
+++ b/plugins/cursor/tests/argv.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { collapseArguments, parseArgv, splitArgString } from '../scripts/lib/argv.js';
+
+describe('splitArgString', () => {
+  it('splits on whitespace', () => {
+    expect(splitArgString('--model composer hello world')).toEqual([
+      '--model',
+      'composer',
+      'hello',
+      'world',
+    ]);
+  });
+
+  it('preserves double-quoted spans', () => {
+    expect(splitArgString('--model opus "write a haiku about git"')).toEqual([
+      '--model',
+      'opus',
+      'write a haiku about git',
+    ]);
+  });
+
+  it('preserves single-quoted spans', () => {
+    expect(splitArgString("--flag 'value with spaces'")).toEqual(['--flag', 'value with spaces']);
+  });
+});
+
+describe('parseArgv', () => {
+  it('splits positional vs flags', () => {
+    const r = parseArgv(['--model', 'opus', '--background', 'do', 'thing'], ['background']);
+    expect(r.flags['model']).toBe('opus');
+    expect(r.flags['background']).toBe(true);
+    expect(r.positional).toEqual(['do', 'thing']);
+  });
+
+  it('handles --no-* negation', () => {
+    const r = parseArgv(['--no-force'], ['force']);
+    expect(r.flags['force']).toBe(false);
+  });
+});
+
+describe('collapseArguments', () => {
+  it('returns empty for empty input', () => {
+    expect(collapseArguments('')).toEqual([]);
+    expect(collapseArguments(undefined)).toEqual([]);
+  });
+
+  it('tokenises with quoting', () => {
+    expect(collapseArguments('--model composer "hello world"')).toEqual([
+      '--model',
+      'composer',
+      'hello world',
+    ]);
+  });
+});

--- a/plugins/cursor/tests/browser.test.ts
+++ b/plugins/cursor/tests/browser.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { main as browserMain } from '../scripts/browser.js';
+import { listJobs } from '../scripts/lib/jobs.js';
+import {
+  BROWSER_FALLBACK_FIXTURE,
+  BROWSER_HAPPY_FIXTURE,
+  BROWSER_HAPPY_NESTED_FIXTURE,
+  STUB_BIN,
+  makeTempHome,
+} from './helpers.js';
+
+describe('browser.ts', () => {
+  let tmp: ReturnType<typeof makeTempHome>;
+  const prevHome = process.env.CURSOR_PLUGIN_CC_HOME;
+  const prevBin = process.env.CURSOR_AGENT_BIN;
+  const prevFix = process.env.CURSOR_AGENT_STUB_FIXTURE;
+  const prevCwd = process.cwd();
+
+  beforeEach(() => {
+    tmp = makeTempHome();
+    process.env.CURSOR_PLUGIN_CC_HOME = tmp.dir;
+    process.env.CURSOR_AGENT_BIN = STUB_BIN;
+    process.env.CURSOR_AGENT_STUB_FIXTURE = BROWSER_HAPPY_FIXTURE;
+    process.chdir(tmp.dir);
+  });
+
+  afterEach(() => {
+    process.chdir(prevCwd);
+    if (prevHome === undefined) delete process.env.CURSOR_PLUGIN_CC_HOME;
+    else process.env.CURSOR_PLUGIN_CC_HOME = prevHome;
+    if (prevBin === undefined) delete process.env.CURSOR_AGENT_BIN;
+    else process.env.CURSOR_AGENT_BIN = prevBin;
+    if (prevFix === undefined) delete process.env.CURSOR_AGENT_STUB_FIXTURE;
+    else process.env.CURSOR_AGENT_STUB_FIXTURE = prevFix;
+    tmp.cleanup();
+  });
+
+  it('refuses when description is empty', async () => {
+    const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      const code = await browserMain(['--no-git-check', '--skip-mcp-check', '--', '']);
+      expect(code).toBe(2);
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it('accepts description without a URL and lets Cursor auto-discover', async () => {
+    const outSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    try {
+      const code = await browserMain([
+        '--no-git-check',
+        '--skip-mcp-check',
+        '--',
+        'please verify the app loads on localhost',
+      ]);
+      expect(code).toBe(0);
+    } finally {
+      outSpy.mockRestore();
+    }
+    const jobs = listJobs(tmp.dir);
+    expect(jobs.length).toBe(1);
+    const job = jobs[0]!;
+    expect(job.prompt).toContain('(discover)');
+  });
+
+  it('happy path: chrome-devtools MCP calls → status done', async () => {
+    const outSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    try {
+      const code = await browserMain([
+        '--no-git-check',
+        '--skip-mcp-check',
+        '--',
+        'localhost:3000 verify the homepage shows a login button',
+      ]);
+      expect(code).toBe(0);
+    } finally {
+      outSpy.mockRestore();
+    }
+    const jobs = listJobs(tmp.dir);
+    expect(jobs.length).toBe(1);
+    const job = jobs[0]!;
+    expect(job.status).toBe('done');
+    expect(job.prompt).toContain('BROWSER');
+    expect(job.prompt).toContain('http://localhost:3000');
+    expect(job.cursorChatId).toBe('chat_browser_001');
+  });
+
+  it('happy path: nested tool_use blocks (realistic Cursor schema) are detected', async () => {
+    process.env.CURSOR_AGENT_STUB_FIXTURE = BROWSER_HAPPY_NESTED_FIXTURE;
+    const outSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    try {
+      const code = await browserMain([
+        '--no-git-check',
+        '--skip-mcp-check',
+        '--',
+        'http://localhost:3002 verify homepage loads',
+      ]);
+      expect(code).toBe(0);
+    } finally {
+      outSpy.mockRestore();
+    }
+    const jobs = listJobs(tmp.dir);
+    const job = jobs[0]!;
+    // MCP tool calls are nested in assistant.message.content[] — the post-flight check
+    // must recurse; otherwise it would spuriously mark this as failed.
+    expect(job.status).toBe('done');
+    expect(job.summary ?? '').not.toMatch(/post-flight/i);
+  });
+
+  it('post-flight: curl fallback is flagged in the job record even when shell exits 0', async () => {
+    process.env.CURSOR_AGENT_STUB_FIXTURE = BROWSER_FALLBACK_FIXTURE;
+    const outSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    try {
+      const code = await browserMain([
+        '--no-git-check',
+        '--skip-mcp-check',
+        '--',
+        'http://localhost:3000 verify page loads',
+      ]);
+      // Shell exit mirrors Cursor's exit so the report renders normally in Claude Code.
+      // The "failed" verdict is carried in the persisted job record + the inline warning.
+      expect(code).toBe(0);
+    } finally {
+      outSpy.mockRestore();
+    }
+    const jobs = listJobs(tmp.dir);
+    const job = jobs[0]!;
+    expect(job.status).toBe('failed');
+    expect(job.summary).toMatch(/post-flight/i);
+    expect(job.summary).toMatch(/curl/i);
+  });
+});

--- a/plugins/cursor/tests/cursor.test.ts
+++ b/plugins/cursor/tests/cursor.test.ts
@@ -1,0 +1,104 @@
+import { readFileSync } from 'node:fs';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { buildArgs, resolveModel, runHeadless } from '../scripts/lib/cursor.js';
+import { extractChatId, summariseEvents } from '../scripts/lib/parse.js';
+import { HAPPY_FIXTURE, STUB_BIN, makeTempHome } from './helpers.js';
+
+describe('buildArgs', () => {
+  it('includes the expected flags by default', () => {
+    const args = buildArgs({ prompt: 'hi', model: 'composer-2' });
+    expect(args).toContain('-p');
+    expect(args).toContain('--output-format');
+    expect(args).toContain('stream-json');
+    expect(args).toContain('--trust');
+    expect(args).toContain('--model');
+    expect(args).toContain('composer-2');
+    expect(args.at(-1)).toBe('hi');
+  });
+
+  it('omits --force when force=false', () => {
+    const args = buildArgs({ prompt: 'hi', model: 'auto', force: false });
+    expect(args).not.toContain('--force');
+  });
+
+  it('adds --cloud and --resume when requested', () => {
+    const args = buildArgs({
+      prompt: 'hi',
+      model: 'auto',
+      cloud: true,
+      resumeChatId: 'chat_xyz',
+    });
+    expect(args).toContain('--cloud');
+    expect(args).toContain('--resume=chat_xyz');
+  });
+
+  it('adds --approve-mcps when requested', () => {
+    const args = buildArgs({ prompt: 'hi', model: 'auto', approveMcps: true });
+    expect(args).toContain('--approve-mcps');
+  });
+
+  it('omits --approve-mcps by default', () => {
+    const args = buildArgs({ prompt: 'hi', model: 'auto' });
+    expect(args).not.toContain('--approve-mcps');
+  });
+});
+
+describe('resolveModel', () => {
+  it('maps aliases to real Cursor ids', () => {
+    expect(resolveModel('composer')).toBe('composer-2-fast');
+    expect(resolveModel('fast')).toBe('composer-2-fast');
+    expect(resolveModel('composer-2')).toBe('composer-2');
+    expect(resolveModel('sonnet')).toBe('claude-4.6-sonnet-medium');
+    expect(resolveModel('opus')).toBe('claude-opus-4-7-high');
+    expect(resolveModel('gpt')).toBe('gpt-5.3-codex');
+    expect(resolveModel('grok')).toBe('grok-4-20');
+    expect(resolveModel('gemini')).toBe('gemini-3.1-pro');
+  });
+
+  it('defaults to composer-2-fast when empty', () => {
+    expect(resolveModel(undefined)).toBe('composer-2-fast');
+    expect(resolveModel('')).toBe('composer-2-fast');
+  });
+
+  it('passes unknown ids through unchanged', () => {
+    expect(resolveModel('some-new-model')).toBe('some-new-model');
+  });
+});
+
+describe('runHeadless against stub binary', () => {
+  let tmp: ReturnType<typeof makeTempHome>;
+  const prevBin = process.env.CURSOR_AGENT_BIN;
+  const prevFixture = process.env.CURSOR_AGENT_STUB_FIXTURE;
+
+  beforeEach(() => {
+    tmp = makeTempHome();
+    process.env.CURSOR_AGENT_BIN = STUB_BIN;
+    process.env.CURSOR_AGENT_STUB_FIXTURE = HAPPY_FIXTURE;
+  });
+
+  afterEach(() => {
+    if (prevBin === undefined) delete process.env.CURSOR_AGENT_BIN;
+    else process.env.CURSOR_AGENT_BIN = prevBin;
+    if (prevFixture === undefined) delete process.env.CURSOR_AGENT_STUB_FIXTURE;
+    else process.env.CURSOR_AGENT_STUB_FIXTURE = prevFixture;
+    tmp.cleanup();
+  });
+
+  it('streams events and writes raw log', async () => {
+    const logPath = `${tmp.dir}/run.ndjson`;
+    const result = await runHeadless({
+      prompt: 'hi',
+      model: 'composer-2',
+      force: false,
+      logPath,
+      timeoutSec: 10,
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.events.length).toBeGreaterThan(0);
+    const raw = readFileSync(logPath, 'utf8');
+    expect(raw.split('\n').filter(Boolean).length).toBeGreaterThan(0);
+    expect(extractChatId(result.events)).toBe('chat_abc123');
+    const summary = summariseEvents(result.events);
+    expect(summary.filesTouched.length).toBeGreaterThan(0);
+  });
+});

--- a/plugins/cursor/tests/delegate.fg.test.ts
+++ b/plugins/cursor/tests/delegate.fg.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { main as delegateMain } from '../scripts/delegate.js';
+import { listJobs } from '../scripts/lib/jobs.js';
+import { HAPPY_FIXTURE, STUB_BIN, makeTempHome } from './helpers.js';
+
+describe('delegate.ts foreground', () => {
+  let tmp: ReturnType<typeof makeTempHome>;
+  const prevHome = process.env.CURSOR_PLUGIN_CC_HOME;
+  const prevBin = process.env.CURSOR_AGENT_BIN;
+  const prevFix = process.env.CURSOR_AGENT_STUB_FIXTURE;
+  const prevCwd = process.cwd();
+
+  beforeEach(() => {
+    tmp = makeTempHome();
+    process.env.CURSOR_PLUGIN_CC_HOME = tmp.dir;
+    process.env.CURSOR_AGENT_BIN = STUB_BIN;
+    process.env.CURSOR_AGENT_STUB_FIXTURE = HAPPY_FIXTURE;
+    process.chdir(tmp.dir);
+  });
+
+  afterEach(() => {
+    process.chdir(prevCwd);
+    if (prevHome === undefined) delete process.env.CURSOR_PLUGIN_CC_HOME;
+    else process.env.CURSOR_PLUGIN_CC_HOME = prevHome;
+    if (prevBin === undefined) delete process.env.CURSOR_AGENT_BIN;
+    else process.env.CURSOR_AGENT_BIN = prevBin;
+    if (prevFix === undefined) delete process.env.CURSOR_AGENT_STUB_FIXTURE;
+    else process.env.CURSOR_AGENT_STUB_FIXTURE = prevFix;
+    tmp.cleanup();
+  });
+
+  it('runs to completion and records a finished job', async () => {
+    const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    try {
+      const code = await delegateMain([
+        '--no-git-check',
+        '--model',
+        'composer',
+        '--',
+        'hello world task',
+      ]);
+      expect(code).toBe(0);
+    } finally {
+      writeSpy.mockRestore();
+    }
+    const jobs = listJobs(tmp.dir);
+    expect(jobs.length).toBe(1);
+    const job = jobs[0]!;
+    expect(job.status).toBe('done');
+    expect(job.model).toBe('composer-2-fast');
+    expect(job.cursorChatId).toBe('chat_abc123');
+    expect(job.filesTouched?.length ?? 0).toBeGreaterThan(0);
+  });
+
+  it('refuses outside a git repo without --no-git-check', async () => {
+    const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      const code = await delegateMain(['--', 'nope']);
+      expect(code).toBe(2);
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it('errors with exit 2 when no prompt is given', async () => {
+    const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      const code = await delegateMain(['--no-git-check']);
+      expect(code).toBe(2);
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+});

--- a/plugins/cursor/tests/fixtures/cursor-agent-stub.mjs
+++ b/plugins/cursor/tests/fixtures/cursor-agent-stub.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+// Test stub for `cursor-agent`. Emits a fixture NDJSON stream chosen by
+// the CURSOR_AGENT_STUB_FIXTURE env var, then exits.
+import { readFileSync } from 'node:fs';
+
+const fixture = process.env.CURSOR_AGENT_STUB_FIXTURE;
+if (!fixture) {
+  process.stderr.write('stub: CURSOR_AGENT_STUB_FIXTURE not set\n');
+  process.exit(2);
+}
+
+let content;
+try {
+  content = readFileSync(fixture, 'utf8');
+} catch (err) {
+  process.stderr.write(`stub: failed to read fixture ${fixture}: ${err.message}\n`);
+  process.exit(2);
+}
+
+const lines = content.split('\n').filter((l) => l.length > 0);
+let failure = false;
+for (const line of lines) {
+  process.stdout.write(line + '\n');
+  try {
+    const parsed = JSON.parse(line);
+    if (parsed && parsed.type === 'result' && parsed.is_error === true) {
+      failure = true;
+    }
+  } catch {
+    /* noop */
+  }
+}
+
+if (process.env.CURSOR_AGENT_STUB_HANG === '1') {
+  // Simulate cursor-agent not self-exiting after `result`.
+  setInterval(() => {}, 1_000);
+} else {
+  process.exit(failure ? 1 : 0);
+}

--- a/plugins/cursor/tests/fixtures/cursor-events/browser-fallback.ndjson
+++ b/plugins/cursor/tests/fixtures/cursor-events/browser-fallback.ndjson
@@ -1,0 +1,5 @@
+{"type":"system","subtype":"init","session_id":"chat_browser_bad"}
+{"type":"assistant","message":{"text":"MCP seems unavailable, trying curl instead."}}
+{"type":"tool_use","name":"bash","input":{"command":"curl -sS -o /dev/null -w '%{http_code}' http://localhost:3000"}}
+{"type":"tool_result","tool_use_id":"1","is_error":false,"content":"200"}
+{"type":"result","subtype":"success","chat_id":"chat_browser_bad","result":"PASS. curl got 200 OK."}

--- a/plugins/cursor/tests/fixtures/cursor-events/browser-happy-nested.ndjson
+++ b/plugins/cursor/tests/fixtures/cursor-events/browser-happy-nested.ndjson
@@ -1,0 +1,11 @@
+{"type":"system","subtype":"init","session_id":"chat_br_nested_1"}
+{"type":"assistant","message":{"id":"msg_1","content":[{"type":"text","text":"Opening the browser and running checks."}]}}
+{"type":"assistant","message":{"id":"msg_2","content":[{"type":"tool_use","id":"tu_1","name":"mcp_chrome-devtools_list_pages","input":{}}]}}
+{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"tu_1","content":"[]"}]}}
+{"type":"assistant","message":{"id":"msg_3","content":[{"type":"tool_use","id":"tu_2","name":"mcp_chrome-devtools_new_page","input":{"url":"http://localhost:3002"}}]}}
+{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"tu_2","content":"pageId=p1"}]}}
+{"type":"assistant","message":{"id":"msg_4","content":[{"type":"tool_use","id":"tu_3","name":"mcp_chrome-devtools_take_snapshot","input":{"pageId":"p1"}}]}}
+{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"tu_3","content":"tree"}]}}
+{"type":"assistant","message":{"id":"msg_5","content":[{"type":"tool_use","id":"tu_4","name":"mcp_chrome-devtools_take_screenshot","input":{"pageId":"p1"}}]}}
+{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"tu_4","content":"shot.png"}]}}
+{"type":"result","subtype":"success","chat_id":"chat_br_nested_1","result":"PASS. Page loaded, no console errors, screenshot saved."}

--- a/plugins/cursor/tests/fixtures/cursor-events/browser-happy.ndjson
+++ b/plugins/cursor/tests/fixtures/cursor-events/browser-happy.ndjson
@@ -1,0 +1,13 @@
+{"type":"system","subtype":"init","session_id":"chat_browser_001"}
+{"type":"assistant","message":{"text":"Opening the page and running verification."}}
+{"type":"tool_use","name":"mcp_chrome-devtools_list_pages","input":{}}
+{"type":"tool_result","tool_use_id":"1","is_error":false,"content":"[]"}
+{"type":"tool_use","name":"mcp_chrome-devtools_new_page","input":{"url":"http://localhost:3000"}}
+{"type":"tool_result","tool_use_id":"2","is_error":false,"content":"pageId=p1"}
+{"type":"tool_use","name":"mcp_chrome-devtools_take_snapshot","input":{"pageId":"p1"}}
+{"type":"tool_result","tool_use_id":"3","is_error":false,"content":"tree"}
+{"type":"tool_use","name":"mcp_chrome-devtools_list_console_messages","input":{"types":["error"]}}
+{"type":"tool_result","tool_use_id":"4","is_error":false,"content":"[]"}
+{"type":"tool_use","name":"mcp_chrome-devtools_take_screenshot","input":{"pageId":"p1"}}
+{"type":"tool_result","tool_use_id":"5","is_error":false,"content":"shot-abc.png"}
+{"type":"result","subtype":"success","chat_id":"chat_browser_001","result":"PASS. Page loaded; no console errors; screenshot saved."}

--- a/plugins/cursor/tests/fixtures/cursor-events/failure.ndjson
+++ b/plugins/cursor/tests/fixtures/cursor-events/failure.ndjson
@@ -1,0 +1,5 @@
+{"type":"system","subtype":"init","session_id":"chat_fail_999"}
+{"type":"assistant","message":{"text":"Attempting the task."}}
+{"type":"tool_use","name":"write","input":{"path":"src/bar.ts","content":"broken"}}
+{"type":"tool_result","tool_use_id":"1","is_error":true,"content":"permission denied"}
+{"type":"result","subtype":"error","chat_id":"chat_fail_999","is_error":true,"result":"Aborted due to error."}

--- a/plugins/cursor/tests/fixtures/cursor-events/happy-path.ndjson
+++ b/plugins/cursor/tests/fixtures/cursor-events/happy-path.ndjson
@@ -1,0 +1,7 @@
+{"type":"system","subtype":"init","session_id":"chat_abc123","cwd":"/tmp/repo"}
+{"type":"assistant","message":{"text":"Starting work on the requested task."}}
+{"type":"tool_use","name":"write","input":{"path":"src/foo.ts","content":"export const foo = 42;\n"}}
+{"type":"tool_result","tool_use_id":"1","is_error":false,"content":"file written"}
+{"type":"tool_use","name":"edit","input":{"file_path":"README.md","old":"TODO","new":"done"}}
+{"type":"tool_result","tool_use_id":"2","is_error":false,"content":"ok"}
+{"type":"result","subtype":"success","chat_id":"chat_abc123","result":"Added src/foo.ts and updated README.md."}

--- a/plugins/cursor/tests/helpers.ts
+++ b/plugins/cursor/tests/helpers.ts
@@ -1,0 +1,29 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+export function makeTempHome(): { dir: string; cleanup: () => void } {
+  const dir = mkdtempSync(join(tmpdir(), 'cursor-plugin-cc-test-'));
+  return {
+    dir,
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+export const STUB_BIN = new URL('./fixtures/cursor-agent-stub.mjs', import.meta.url).pathname;
+export const HAPPY_FIXTURE = new URL('./fixtures/cursor-events/happy-path.ndjson', import.meta.url)
+  .pathname;
+export const FAILURE_FIXTURE = new URL('./fixtures/cursor-events/failure.ndjson', import.meta.url)
+  .pathname;
+export const BROWSER_HAPPY_FIXTURE = new URL(
+  './fixtures/cursor-events/browser-happy.ndjson',
+  import.meta.url,
+).pathname;
+export const BROWSER_HAPPY_NESTED_FIXTURE = new URL(
+  './fixtures/cursor-events/browser-happy-nested.ndjson',
+  import.meta.url,
+).pathname;
+export const BROWSER_FALLBACK_FIXTURE = new URL(
+  './fixtures/cursor-events/browser-fallback.ndjson',
+  import.meta.url,
+).pathname;

--- a/plugins/cursor/tests/jobs.test.ts
+++ b/plugins/cursor/tests/jobs.test.ts
@@ -1,0 +1,97 @@
+import { spawn } from 'node:child_process';
+import { utimesSync } from 'node:fs';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  cancelJob,
+  createJob,
+  findRunningJobs,
+  jobFilePath,
+  listJobs,
+  mostRecentFinishedJob,
+  pruneOlderThanDays,
+  readJob,
+  updateJob,
+} from '../scripts/lib/jobs.js';
+import { makeTempHome } from './helpers.js';
+
+describe('jobs registry', () => {
+  let tmp: ReturnType<typeof makeTempHome>;
+  const prevHome = process.env.CURSOR_PLUGIN_CC_HOME;
+  const repo = '/tmp/some-repo-path';
+
+  beforeEach(() => {
+    tmp = makeTempHome();
+    process.env.CURSOR_PLUGIN_CC_HOME = tmp.dir;
+  });
+
+  afterEach(() => {
+    if (prevHome === undefined) delete process.env.CURSOR_PLUGIN_CC_HOME;
+    else process.env.CURSOR_PLUGIN_CC_HOME = prevHome;
+    tmp.cleanup();
+  });
+
+  it('creates, reads, and updates a job atomically', () => {
+    const job = createJob({ id: 'job1', repoPath: repo, prompt: 'do it', model: 'composer-2' });
+    expect(job.status).toBe('running');
+    const read = readJob(repo, 'job1');
+    expect(read?.prompt).toBe('do it');
+    const updated = updateJob(repo, 'job1', {
+      status: 'done',
+      exitCode: 0,
+      finishedAt: new Date().toISOString(),
+    });
+    expect(updated?.status).toBe('done');
+  });
+
+  it('lists jobs sorted newest first and filters by status', () => {
+    createJob({ id: 'a', repoPath: repo, prompt: 'a', model: 'x' });
+    createJob({ id: 'b', repoPath: repo, prompt: 'b', model: 'x' });
+    updateJob(repo, 'a', { status: 'done', finishedAt: new Date().toISOString() });
+    const all = listJobs(repo);
+    expect(all.length).toBe(2);
+    const running = listJobs(repo, { status: 'running' });
+    expect(running.map((j) => j.id)).toEqual(['b']);
+    expect(findRunningJobs(repo).map((j) => j.id)).toEqual(['b']);
+    expect(mostRecentFinishedJob(repo)?.id).toBe('a');
+  });
+
+  it('prunes stale job files', () => {
+    createJob({ id: 'old', repoPath: repo, prompt: 'old', model: 'x' });
+    createJob({ id: 'new', repoPath: repo, prompt: 'new', model: 'x' });
+    const stalePath = jobFilePath(repo, 'old');
+    const past = new Date(Date.now() - 60 * 24 * 3600 * 1000);
+    utimesSync(stalePath, past, past);
+    const removed = pruneOlderThanDays(repo, 30);
+    expect(removed).toBeGreaterThanOrEqual(1);
+    expect(readJob(repo, 'old')).toBeNull();
+    expect(readJob(repo, 'new')).not.toBeNull();
+  });
+
+  it('cancelJob SIGTERMs a live pid and marks cancelled', async () => {
+    const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
+      stdio: 'ignore',
+      detached: false,
+    });
+    try {
+      await new Promise((r) => setTimeout(r, 50));
+      createJob({ id: 'live', repoPath: repo, prompt: 'p', model: 'm' });
+      updateJob(repo, 'live', { pid: child.pid! });
+      const cancelled = await cancelJob(repo, 'live', 500);
+      expect(cancelled?.status).toBe('cancelled');
+    } finally {
+      if (!child.killed) child.kill('SIGKILL');
+    }
+  });
+
+  it('cancelJob on unknown id returns null', async () => {
+    const res = await cancelJob(repo, 'nope');
+    expect(res).toBeNull();
+  });
+
+  it('cancelJob on already-finished job returns unchanged record', async () => {
+    createJob({ id: 'done1', repoPath: repo, prompt: 'p', model: 'm' });
+    updateJob(repo, 'done1', { status: 'done' });
+    const res = await cancelJob(repo, 'done1');
+    expect(res?.status).toBe('done');
+  });
+});

--- a/plugins/cursor/tests/parse.test.ts
+++ b/plugins/cursor/tests/parse.test.ts
@@ -1,0 +1,59 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import {
+  extractChatId,
+  parseLine,
+  summariseEvents,
+  type CursorEvent,
+} from '../scripts/lib/parse.js';
+import { FAILURE_FIXTURE, HAPPY_FIXTURE } from './helpers.js';
+
+function loadFixture(path: string): CursorEvent[] {
+  const raw = readFileSync(path, 'utf8');
+  const out: CursorEvent[] = [];
+  for (const line of raw.split('\n')) {
+    const ev = parseLine(line);
+    if (ev) out.push(ev);
+  }
+  return out;
+}
+
+describe('parse', () => {
+  it('drops empty and malformed lines', () => {
+    expect(parseLine('')).toBeNull();
+    expect(parseLine('   ')).toBeNull();
+    expect(parseLine('not json')).toBeNull();
+    expect(parseLine('null')).toBeNull();
+    expect(parseLine('{"type":"x"}')?.type).toBe('x');
+  });
+
+  it('extracts chat id from the happy-path stream', () => {
+    const events = loadFixture(HAPPY_FIXTURE);
+    expect(extractChatId(events)).toBe('chat_abc123');
+  });
+
+  it('extracts chat id from the failure stream', () => {
+    const events = loadFixture(FAILURE_FIXTURE);
+    expect(extractChatId(events)).toBe('chat_fail_999');
+  });
+
+  it('returns undefined when no chat id present', () => {
+    expect(extractChatId([{ type: 'assistant' }])).toBeUndefined();
+  });
+
+  it('summarises happy-path: files touched + success text', () => {
+    const events = loadFixture(HAPPY_FIXTURE);
+    const s = summariseEvents(events);
+    expect(s.success).toBe(true);
+    expect(s.filesTouched).toEqual(expect.arrayContaining(['src/foo.ts', 'README.md']));
+    expect(s.summary).toContain('Added src/foo.ts');
+  });
+
+  it('summarises failure stream: success=false and error reason', () => {
+    const events = loadFixture(FAILURE_FIXTURE);
+    const s = summariseEvents(events);
+    expect(s.success).toBe(false);
+    expect(s.exitReason).toBe('error');
+    expect(s.summary).toContain('Aborted');
+  });
+});

--- a/plugins/cursor/tests/paths.test.ts
+++ b/plugins/cursor/tests/paths.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { pluginHome, repoHash, jobsDir } from '../scripts/lib/paths.js';
+import { makeTempHome } from './helpers.js';
+
+describe('paths', () => {
+  let tmp: ReturnType<typeof makeTempHome>;
+  const prevHome = process.env.CURSOR_PLUGIN_CC_HOME;
+
+  beforeEach(() => {
+    tmp = makeTempHome();
+    process.env.CURSOR_PLUGIN_CC_HOME = tmp.dir;
+  });
+
+  afterEach(() => {
+    if (prevHome === undefined) delete process.env.CURSOR_PLUGIN_CC_HOME;
+    else process.env.CURSOR_PLUGIN_CC_HOME = prevHome;
+    tmp.cleanup();
+  });
+
+  it('pluginHome honours the env override', () => {
+    expect(pluginHome()).toBe(tmp.dir);
+  });
+
+  it('repoHash is stable and 12 hex chars', () => {
+    const a = repoHash(tmp.dir);
+    const b = repoHash(tmp.dir);
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[0-9a-f]{12}$/);
+  });
+
+  it('jobsDir nests under pluginHome', () => {
+    const dir = jobsDir(tmp.dir);
+    expect(dir.startsWith(tmp.dir)).toBe(true);
+    expect(dir).toContain('jobs');
+  });
+});

--- a/plugins/cursor/tsconfig.build.json
+++ b/plugins/cursor/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": "scripts",
+    "declaration": false,
+    "sourceMap": false
+  },
+  "include": ["scripts/**/*.ts"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/plugins/cursor/tsconfig.json
+++ b/plugins/cursor/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noImplicitOverride": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    "exactOptionalPropertyTypes": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["scripts/**/*.ts", "tests/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/plugins/cursor/vitest.config.ts
+++ b/plugins/cursor/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: false,
+    include: ['tests/**/*.test.ts'],
+    testTimeout: 15_000,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html'],
+      include: ['scripts/lib/**/*.ts'],
+      thresholds: {
+        lines: 80,
+        functions: 75,
+        statements: 80,
+        branches: 70,
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- Bootstraps `cursor-plugin-cc` — a Claude Code plugin that delegates coding tasks to the Cursor CLI (`cursor-agent`), modelled after `openai/codex-plugin-cc`.
- Eight slash commands: `delegate`, `browser`, `status`, `result`, `cancel`, `resume`, `sessions`, `setup`. Plus a `cursor-runner` subagent enforcing a strict prompt template (goal / repo context / acceptance criteria / files / how-to-verify).
- Default model `composer-2-fast` (Cursor's own current default). Model aliases validated against real `cursor-agent --list-models` output.
- `/cursor:browser` wraps Cursor's `chrome-devtools` MCP with auto-URL-discovery, `--approve-mcps`, a post-flight check that flags `curl`/`wget` fallback even when Cursor reports PASS, and a recursive `tool_use` walker that handles both the Anthropic-nested schema and flatter variants.
- File-backed job registry at `~/.cursor-plugin-cc/jobs/<repo-hash>/` with atomic writes, 30-day pruning, background worker re-exec, and SIGTERM→SIGKILL cancellation.
- TypeScript compiled to `dist/` via `npm prepare` hook. Slash commands invoke `node "${CLAUDE_PLUGIN_ROOT}/dist/<cmd>.js"` with `Bash(node:*)` permission — the pattern used by `codex-plugin-cc`.

## Test plan

- [x] `npm run typecheck` — 0 errors with strict + `exactOptionalPropertyTypes`.
- [x] `npm test` — 39/39 vitest specs (unit + fixtures + stub `cursor-agent`).
- [x] `npm run lint` — prettier + eslint clean.
- [x] `/cursor:setup --doctor` on macOS + `cursor-agent` 2026.04.17 — all checks pass incl. configured MCPs (`chrome-devtools`, `pixellab`).
- [x] `/cursor:delegate` smoke-tested against real `cursor-agent` against another repo — job recorded, chat id captured, summary rendered.
- [x] `/cursor:browser` smoke-tested against real `chrome-devtools` MCP — 30+ MCP calls, no false-positive post-flight warnings after the nested-schema parser fix.
- [ ] CI green on Node 18.18 / 20 / 22 × Ubuntu / macOS.
- [ ] Manual smoke of `/cursor:cancel`, `/cursor:resume`, `/cursor:sessions`.

## Notes

- After merge, enable branch protection on `main` (required reviews + required status checks = `test` matrix jobs).
- Release flow: tag `v0.1.0` on `main`, `gh release create v0.1.0 --notes-file CHANGELOG.md`.
- Firefox DevTools MCP support (Mozilla `firefox-devtools-mcp`) is on the roadmap but NOT in this PR — see `CHANGELOG.md` → Unreleased.