### PR TITLE
feat(from-plan): bridge Claude Code plan mode → Cursor delegate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.2.0 — plan-mode bridge + zero-deps rewrite
+
+### Added
+
+- **`/cursor:from-plan`** — new command that turns a Claude Code plan file (`~/.claude/plans/<slug>.md`) into a Cursor-shaped task file under `tasks/<YYYYMMDD-HHmm>-<slug>.md` and optionally auto-invokes `/cursor:delegate` with it. Bridges Claude's plan mode directly into the Cursor execution flow. `--list` lists recent plans; `--delegate` / `--yes` skips the preview step.
 
 ### Changed
 
 - Rewrote the plugin as **zero-dependency `.mjs`** (no TypeScript, no runtime packages). Sources under `scripts/` are what ships — Claude Code executes them directly after `/plugin install`, no build step, no cache-time `npm install`. Matches the `openai/codex-plugin-cc` shape. `execa`/`zod`/`nanoid`/`yargs-parser` are gone; replaced by `scripts/lib/run.mjs`, `scripts/lib/id.mjs`, `scripts/lib/args.mjs` and plain JSON handling.
 - Slash-command bodies now invoke `node "${CLAUDE_PLUGIN_ROOT}/scripts/<cmd>.mjs"` (was `dist/<cmd>.js`).
+- Robust entry-point detection (`lib/invoked.mjs`) — `realpathSync` on both sides, fixes a silent no-op when the plugin was executed through a symlinked path (e.g. macOS `/tmp → /private/tmp`).
 
 ### Planned
 
 - Support additional browser-automation MCPs (next target: Mozilla [firefox-devtools-mcp](https://github.com/mozilla/firefox-devtools-mcp)). `/cursor:browser` will grow a `--mcp <name>` flag and autodiscover from `cursor-agent mcp list`.
 - Repo-local `.cursor-plugin-cc.json` for per-project default model / timeout / MCP preference.
+- `/cursor:task new "<slug>"`, `/cursor:diff [job-id]`, `/cursor:retry [job-id]` — quality-of-life commands.
 
 ## 0.1.0 — initial release
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ A [Claude Code](https://claude.com/claude-code) plugin that hands off coding tas
 
 ## What you get
 
-Eight slash commands under the `cursor:` namespace:
+Nine slash commands under the `cursor:` namespace:
 
 - **`/cursor:delegate`** — hand a coding task to Cursor, foreground or background.
+- **`/cursor:from-plan`** — turn a Claude Code plan (from plan mode) into a `tasks/<file>.md` and hand it off to Cursor.
 - **`/cursor:browser`** — verify a URL / flow in a real browser via Cursor's `chrome-devtools` MCP.
 - **`/cursor:status`** — list recent jobs or inspect a specific one.
 - **`/cursor:result`** — print the final output of a finished job.
@@ -98,6 +99,30 @@ Examples:
 /cursor:delegate --background --model auto "migrate user repository to Doctrine 3"
 /cursor:delegate --resume "continue with the failing edge case"
 ```
+
+### `/cursor:from-plan [plan-name] [--delegate] [--model <id>] [--background] [--list]`
+
+Takes a Claude Code **plan file** (anything written under `~/.claude/plans/` by Claude's plan mode) and rewrites it as a Cursor-shaped task file under `tasks/<YYYYMMDD-HHmm>-<slug>.md`. The task file has the standard five sections (Goal, Repo context, Acceptance criteria, Files to touch, How to verify) plus a guardrail block — exactly the shape the `cursor-runner` subagent enforces — and a link back to the source plan.
+
+Two modes:
+
+- **Preview + hand-back** (default): writes the task file, prints the exact `/cursor:delegate @tasks/…` command to run next. Lets you review the task before any Cursor tokens get spent.
+- **Auto-delegate** (`--delegate` / `--yes`): writes the task file AND invokes `/cursor:delegate` in one go. Use when you already trust the plan.
+
+Examples:
+
+```
+# Plan mode first — Claude drops the plan under ~/.claude/plans/<slug>.md
+# when you exit plan mode. Then:
+
+/cursor:from-plan                       # newest plan → tasks/ → print delegate command
+/cursor:from-plan dark-mode             # match on a plan name fragment
+/cursor:from-plan --delegate            # newest plan → tasks/ → delegate immediately
+/cursor:from-plan --delegate --model opus --background "some-slug"
+/cursor:from-plan --list                # show the 15 most recent plans
+```
+
+This is the closest thing to "plan in Claude, execute in Cursor" in one session: Claude does the thinking, Cursor does the typing, and the task file is a durable contract between the two.
 
 ### `/cursor:browser <url> <what to verify...>`
 
@@ -243,6 +268,26 @@ The two-phase loop above is the concept; here is the concrete workflow that fall
 Why this works: Claude's tokens go into **planning and reviewing**, where thinking matters; Cursor's Composer 2 handles **the actual typing**, where it is cheaper and faster. The task file is the contract between the two phases — if it is sloppy, no model will save you. Writing a good one is itself a skill, and it is the only skill this workflow asks of you.
 
 If you want Claude to do the whole thing automatically — draft the task file AND hand it off — that is what the `cursor-runner` subagent is for. Ask it to either "draft a task file for X" (it stops there) or "implement X via Cursor" (it drafts, hands off, and reports the diff).
+
+### Bonus: plan mode → `/cursor:from-plan` → delegate
+
+If you already used Claude Code's **plan mode** for a task (the `/plan …` flow that drops a plan file under `~/.claude/plans/<slug>.md` after you approve it), you do not need to re-type anything. Run `/cursor:from-plan` and the plugin will:
+
+1. Pick the newest plan under `~/.claude/plans/` (or the one matching a name fragment you pass).
+2. Extract the useful sections (Context → Repo context, Approach → Acceptance criteria, File list → Files to touch, Verification → How to verify), drop the dev-only bits (Effort, Risks, Scope exclusions), and add the standard guardrail block.
+3. Write the result to `tasks/<YYYYMMDD-HHmm>-<slug>.md` in the current repo and print the exact `/cursor:delegate @tasks/…` command for you to run.
+
+So the full loop is:
+
+```
+/plan add a dark-mode toggle to the settings page
+# Claude proposes a plan; you approve inside plan mode.
+/cursor:from-plan --delegate --model opus
+# Plan gets turned into a task file and handed off to Cursor in one step.
+# Back in Claude Code: review the diff, /cursor:resume "fix X" if needed.
+```
+
+The task file stays in `tasks/` as a durable record — the contract between plan and execution. Re-running a similar slice later is a two-line diff of that file away.
 
 ## Configuration
 

--- a/plugins/cursor/commands/from-plan.md
+++ b/plugins/cursor/commands/from-plan.md
@@ -1,0 +1,14 @@
+---
+description: Convert a Claude Code plan file into a tasks/<file>.md and optionally hand it off to Cursor.
+argument-hint: '[plan-name-fragment] [--delegate] [--model <id>] [--background] [--list]'
+allowed-tools: Bash(node:*)
+---
+
+!`node "${CLAUDE_PLUGIN_ROOT}/scripts/from-plan.mjs" -- "$ARGUMENTS"`
+
+Render the output verbatim. The command has two modes:
+
+- **Preview + hand back** (default): it writes `tasks/<file>.md`, then prints the exact `/cursor:delegate @tasks/…` command. Run that command yourself after reviewing the task file.
+- **Auto-delegate** (`--delegate` or `--yes`): it writes the task file AND immediately calls `/cursor:delegate`, so the output merges into a single flow.
+
+Without arguments it picks the newest plan under `~/.claude/plans/`. Pass a name fragment (e.g. `dark-mode`) to pick a specific one. `--list` shows the 15 most recent plan files.

--- a/plugins/cursor/package.json
+++ b/plugins/cursor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cursor-plugin-cc",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Use Cursor CLI from Claude Code to delegate coding tasks to Composer 2 and other Cursor models.",
   "type": "module",
   "license": "MIT",

--- a/plugins/cursor/plugin.json
+++ b/plugins/cursor/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cursor",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Hand off tasks from Claude Code to cursor-agent. Composer 2 optimised.",
   "author": {
     "name": "Tomas Grasl",

--- a/plugins/cursor/scripts/from-plan.mjs
+++ b/plugins/cursor/scripts/from-plan.mjs
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+// /cursor:from-plan — convert a Claude Code plan file into a task file under
+// `tasks/` in the current repo, and optionally hand it off to Cursor via
+// `/cursor:delegate @tasks/<file>`.
+//
+// Typical flow:
+//   1. User runs /plan mode in Claude Code, Claude writes a plan to
+//      ~/.claude/plans/<slug>.md.
+//   2. User runs /cursor:from-plan.
+//   3. We read the latest plan, extract its sections (Context, Approach,
+//      Files, Verification), re-emit them as a Cursor-shaped task file at
+//      tasks/<YYYYMMDD-HHmm>-<slug>.md, and print the recommended delegate
+//      command.
+//   4. With --delegate (or --yes), we invoke delegate directly in-process
+//      and stream its output.
+
+import { existsSync, writeFileSync } from 'node:fs';
+import { mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { collapseArguments, parseArgv } from './lib/args.mjs';
+import { main as delegateMain } from './delegate.mjs';
+import { repoRoot } from './lib/git.mjs';
+import { buildTaskContent, listPlans, parsePlanFile, resolvePlanPath } from './lib/plan.mjs';
+import { invokedAsScript as __isScript } from './lib/invoked.mjs';
+
+const BOOLEAN_FLAGS = [
+  'delegate',
+  'yes',
+  'background',
+  'fresh',
+  'force',
+  'git-check',
+  'list',
+  'help',
+];
+
+function parseFlags(argv) {
+  const { positional, flags } = parseArgv(argv, BOOLEAN_FLAGS);
+  const shouldDelegate = flags['delegate'] === true || flags['yes'] === true || flags['y'] === true;
+  const background = Boolean(flags['background']);
+  const fresh = Boolean(flags['fresh']);
+  const force = 'force' in flags ? Boolean(flags['force']) : true;
+  const noGitCheck =
+    flags['gitCheck'] === false || flags['git-check'] === false || flags['no-git-check'] === true;
+  const list = Boolean(flags['list']);
+  const model = typeof flags['model'] === 'string' ? flags['model'] : undefined;
+  const timeoutRaw = flags['timeout'];
+  const timeout =
+    typeof timeoutRaw === 'number' ? timeoutRaw : timeoutRaw ? Number(timeoutRaw) : undefined;
+  const planRef = positional[0];
+  return {
+    planRef,
+    shouldDelegate,
+    background,
+    fresh,
+    force,
+    noGitCheck,
+    list,
+    model,
+    timeout,
+  };
+}
+
+function timestamp() {
+  const d = new Date();
+  const pad = (n) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}${pad(d.getMonth() + 1)}${pad(d.getDate())}-${pad(d.getHours())}${pad(d.getMinutes())}`;
+}
+
+function renderPlansList() {
+  const plans = listPlans();
+  if (plans.length === 0) {
+    return '_No plan files found at `~/.claude/plans/`._\n';
+  }
+  const lines = [
+    '### Available Claude Code plans (newest first)\n',
+    '| Name | Modified |',
+    '| --- | --- |',
+  ];
+  for (const p of plans.slice(0, 15)) {
+    const age = Math.round((Date.now() - p.mtimeMs) / 60_000);
+    const when =
+      age < 60
+        ? `${age}m ago`
+        : age < 1440
+          ? `${Math.round(age / 60)}h ago`
+          : `${Math.round(age / 1440)}d ago`;
+    lines.push(`| \`${p.name}\` | ${when} |`);
+  }
+  lines.push('');
+  lines.push(
+    'Use `/cursor:from-plan <name-fragment>` to pick one. With no argument, the newest plan is used.',
+  );
+  return lines.join('\n') + '\n';
+}
+
+function writeTaskFile(root, slug, content) {
+  const tasksDir = join(root, 'tasks');
+  if (!existsSync(tasksDir)) mkdirSync(tasksDir, { recursive: true });
+  const fullPath = join(tasksDir, `${timestamp()}-${slug}.md`);
+  writeFileSync(fullPath, content, 'utf8');
+  return { fullPath };
+}
+
+/**
+ * @param {string[]} rawArgv
+ * @returns {Promise<number>}
+ */
+export async function main(rawArgv) {
+  const delimiterIdx = rawArgv.indexOf('--');
+  const firstHalf = delimiterIdx === -1 ? [] : rawArgv.slice(0, delimiterIdx);
+  const userRaw =
+    delimiterIdx === -1 ? rawArgv.join(' ') : rawArgv.slice(delimiterIdx + 1).join(' ');
+  const combined = [...firstHalf, ...collapseArguments(userRaw)];
+  const flags = parseFlags(combined);
+
+  if (flags.list) {
+    process.stdout.write(renderPlansList());
+    return 0;
+  }
+
+  const planPath = resolvePlanPath(flags.planRef);
+  if (!planPath) {
+    if (flags.planRef) {
+      process.stderr.write(
+        `Error: no plan file matches \`${flags.planRef}\`. Run \`/cursor:from-plan --list\` to see available plans.\n`,
+      );
+    } else {
+      process.stderr.write(
+        'Error: no plan files found. Write one by using plan mode in Claude Code (they are saved under `~/.claude/plans/`).\n',
+      );
+    }
+    return 2;
+  }
+
+  const plan = parsePlanFile(planPath);
+  const root = await repoRoot(process.cwd());
+  const taskContent = buildTaskContent(plan);
+  const { fullPath } = writeTaskFile(root, plan.slug, taskContent);
+  const relPath = fullPath.startsWith(root + '/') ? fullPath.slice(root.length + 1) : fullPath;
+
+  process.stdout.write(`### Task file created\n\n`);
+  process.stdout.write(`- **Source plan:** \`${planPath}\`\n`);
+  process.stdout.write(`- **Task file:** \`${relPath}\`\n`);
+  process.stdout.write(`- **Title:** ${plan.title || '(untitled)'}\n\n`);
+
+  if (!flags.shouldDelegate) {
+    process.stdout.write('---\n\n');
+    process.stdout.write('Review the task file, then delegate it to Cursor:\n\n');
+    process.stdout.write('```\n');
+    const modelFlag = flags.model ? ` --model ${flags.model}` : '';
+    const bgFlag = flags.background ? ' --background' : '';
+    const freshFlag = flags.fresh ? ' --fresh' : '';
+    process.stdout.write(`/cursor:delegate${modelFlag}${bgFlag}${freshFlag} @${relPath}\n`);
+    process.stdout.write('```\n\n');
+    process.stdout.write(
+      'Re-run with `--delegate` (or `--yes`) to skip the review and hand it off right away.\n',
+    );
+    return 0;
+  }
+
+  // Auto-delegate: call delegate.mjs in-process. We pass the task file as
+  // part of the prompt using the same `@path` convention Claude Code uses.
+  const delegateArgs = [];
+  if (flags.noGitCheck) delegateArgs.push('--no-git-check');
+  if (flags.model) delegateArgs.push('--model', flags.model);
+  if (flags.background) delegateArgs.push('--background');
+  if (flags.fresh) delegateArgs.push('--fresh');
+  if (!flags.force) delegateArgs.push('--no-force');
+  if (typeof flags.timeout === 'number') delegateArgs.push('--timeout', String(flags.timeout));
+  delegateArgs.push('--', `Implement the task described in @${relPath}. Follow every section.`);
+
+  process.stdout.write('---\n\nHanding off to Cursor…\n\n');
+  return delegateMain(delegateArgs);
+}
+
+const invokedAsScript = __isScript(import.meta.url);
+
+if (invokedAsScript) {
+  main(process.argv.slice(2))
+    .then((code) => process.exit(code))
+    .catch((err) => {
+      process.stderr.write(
+        `from-plan failed: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}\n`,
+      );
+      process.exit(1);
+    });
+}

--- a/plugins/cursor/scripts/lib/plan.mjs
+++ b/plugins/cursor/scripts/lib/plan.mjs
@@ -1,0 +1,246 @@
+// Helpers for reading Claude Code plan files and converting them into
+// Cursor-oriented task files.
+//
+// Claude Code writes plans to `~/.claude/plans/<random-slug>.md` when the
+// model exits plan mode. Each plan is free-form Markdown but in practice
+// follows a recognisable shape:
+//
+//   # Title
+//
+//   ## Context      — why the change
+//   ## Approach     — how (narrative, paragraphs + sections)
+//   ## File-by-file change list   — files to touch
+//   ## Critical files             — (alternative naming)
+//   ## Verification               — how to check it worked
+//   ## Effort / risks             — dev commentary (we drop this)
+//
+// We never REQUIRE any of those sections; the extractor degrades gracefully
+// and falls back to a pass-through if it cannot parse enough structure.
+
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+export const PLANS_DIR = join(homedir(), '.claude', 'plans');
+
+/**
+ * @typedef {Object} ParsedPlan
+ * @property {string} path                Absolute path to the source plan file.
+ * @property {string} title               First `# ` heading text. May be empty.
+ * @property {string} slug                kebab-case slug derived from title (or file stem).
+ * @property {Object<string, string>} sections   Section body by lowercased heading key.
+ * @property {string} raw                 Full file contents.
+ */
+
+/**
+ * List available plan files sorted by mtime (newest first).
+ *
+ * @param {string} [plansDir]
+ * @returns {Array<{ path: string, name: string, mtimeMs: number }>}
+ */
+export function listPlans(plansDir = PLANS_DIR) {
+  if (!existsSync(plansDir)) return [];
+  const entries = [];
+  for (const name of readdirSync(plansDir)) {
+    if (!name.endsWith('.md')) continue;
+    const p = join(plansDir, name);
+    try {
+      const st = statSync(p);
+      if (st.isFile()) entries.push({ path: p, name, mtimeMs: st.mtimeMs });
+    } catch {
+      continue;
+    }
+  }
+  entries.sort((a, b) => b.mtimeMs - a.mtimeMs);
+  return entries;
+}
+
+/**
+ * Resolve an input identifier (absolute path, filename, or plan-name without
+ * extension) to a real plan file path. Returns undefined if nothing matches.
+ *
+ * @param {string|undefined} ref
+ * @param {string} [plansDir]
+ * @returns {string|undefined}
+ */
+export function resolvePlanPath(ref, plansDir = PLANS_DIR) {
+  if (!ref) {
+    const latest = listPlans(plansDir)[0];
+    return latest?.path;
+  }
+  // Absolute path.
+  if (ref.startsWith('/') || /^[A-Za-z]:/.test(ref)) {
+    return existsSync(ref) ? resolve(ref) : undefined;
+  }
+  // Relative path from CWD.
+  const fromCwd = resolve(process.cwd(), ref);
+  if (existsSync(fromCwd) && !fromCwd.endsWith('/')) return fromCwd;
+  // Filename inside plans dir (with or without .md).
+  const candidates = [join(plansDir, ref), join(plansDir, ref.endsWith('.md') ? ref : `${ref}.md`)];
+  for (const c of candidates) {
+    if (existsSync(c)) return c;
+  }
+  // Substring match against plan names.
+  const needle = ref.toLowerCase();
+  const match = listPlans(plansDir).find((p) => p.name.toLowerCase().includes(needle));
+  return match?.path;
+}
+
+/**
+ * Split a plan markdown into (heading → body) pairs keyed by lowercased heading.
+ * Only `## ` headings are split — deeper headings stay inside the section body.
+ *
+ * @param {string} content
+ * @returns {{ title: string, sections: Object<string, string> }}
+ */
+export function splitSections(content) {
+  const lines = content.split('\n');
+  /** @type {Object<string, string>} */
+  const sections = {};
+  let title = '';
+  let currentKey = '';
+  /** @type {string[]} */
+  let buffer = [];
+  const flush = () => {
+    if (currentKey) {
+      sections[currentKey] =
+        (sections[currentKey] ? sections[currentKey] + '\n\n' : '') + buffer.join('\n').trim();
+    }
+    buffer = [];
+  };
+  for (const line of lines) {
+    const h1 = /^#\s+(.+?)\s*$/.exec(line);
+    if (h1 && !title) {
+      title = h1[1].trim();
+      continue;
+    }
+    const h2 = /^##\s+(.+?)\s*$/.exec(line);
+    if (h2) {
+      flush();
+      currentKey = h2[1].trim().toLowerCase();
+      continue;
+    }
+    buffer.push(line);
+  }
+  flush();
+  return { title, sections };
+}
+
+/**
+ * Read and parse a plan file.
+ *
+ * @param {string} path
+ * @returns {ParsedPlan}
+ */
+export function parsePlanFile(path) {
+  const raw = readFileSync(path, 'utf8');
+  const { title, sections } = splitSections(raw);
+  const slug = slugify(title || path.replace(/\.md$/, '').split('/').pop() || 'plan');
+  return { path, title, slug, sections, raw };
+}
+
+/**
+ * @param {string} s
+ * @returns {string}
+ */
+export function slugify(s) {
+  const cleaned = s
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, ' ')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+  return cleaned.slice(0, 50) || 'plan';
+}
+
+const SECTION_HINTS = {
+  context: ['context', 'background', 'why', 'motivation'],
+  approach: ['approach', 'plan', 'implementation', 'solution', 'design'],
+  files: [
+    'file-by-file change list',
+    'files to touch',
+    'files to modify',
+    'critical files',
+    'critical files to touch',
+    'critical files to modify',
+    'files',
+  ],
+  verification: ['verification', 'how to verify', 'test plan', 'tests', 'acceptance criteria'],
+};
+
+/**
+ * Pick the first matching section for a given intent.
+ *
+ * @param {Object<string, string>} sections
+ * @param {'context'|'approach'|'files'|'verification'} intent
+ * @returns {string}
+ */
+export function pickSection(sections, intent) {
+  const hints = SECTION_HINTS[intent];
+  for (const key of Object.keys(sections)) {
+    for (const hint of hints) {
+      if (key === hint || key.startsWith(`${hint}:`) || key.startsWith(`${hint} `)) {
+        return sections[key];
+      }
+    }
+  }
+  return '';
+}
+
+/**
+ * Build the Cursor-friendly task file content from a parsed plan.
+ *
+ * @param {ParsedPlan} plan
+ * @returns {string}
+ */
+export function buildTaskContent(plan) {
+  const context = pickSection(plan.sections, 'context');
+  const approach = pickSection(plan.sections, 'approach');
+  const files = pickSection(plan.sections, 'files');
+  const verification = pickSection(plan.sections, 'verification');
+
+  const lines = [];
+  lines.push(`# ${plan.title || 'Delegated task'}`);
+  lines.push('');
+  lines.push(`> Generated from Claude Code plan: \`${plan.path}\``);
+  lines.push('');
+  lines.push('## Goal');
+  lines.push('');
+  lines.push(plan.title ? plan.title : '(see Context below)');
+  lines.push('');
+  lines.push('## Repo context');
+  lines.push('');
+  lines.push(context || '(no Context section in the source plan)');
+  lines.push('');
+  lines.push('## Acceptance criteria');
+  lines.push('');
+  lines.push(approach || '(no Approach / Plan / Implementation section in the source plan)');
+  lines.push('');
+  if (files) {
+    lines.push('## Files to touch');
+    lines.push('');
+    lines.push(files);
+    lines.push('');
+  }
+  lines.push('## How to verify');
+  lines.push('');
+  lines.push(
+    verification ||
+      "- Run the project's test suite (`npm test`, `pnpm test`, `task test`, etc.).\n" +
+        '- Run the type-check / lint if the project has one.\n' +
+        '- Manual spot-check of the changed behaviour.',
+  );
+  lines.push('');
+  lines.push('## Constraints');
+  lines.push('');
+  lines.push(
+    '- Follow existing conventions in the target repo (read `AGENTS.md` / `.cursor/rules` / existing code).',
+  );
+  lines.push('- Do not touch files outside the list above unless the task explicitly requires it.');
+  lines.push('- Do not rename public APIs unless the task asks for it.');
+  lines.push(
+    '- Do not modify lockfiles (`package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`) unless dependencies are part of the task.',
+  );
+  lines.push('');
+  return lines.join('\n');
+}

--- a/plugins/cursor/tests/plan.test.mjs
+++ b/plugins/cursor/tests/plan.test.mjs
@@ -1,0 +1,152 @@
+import { mkdirSync, utimesSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  buildTaskContent,
+  listPlans,
+  parsePlanFile,
+  resolvePlanPath,
+  slugify,
+  splitSections,
+} from '../scripts/lib/plan.mjs';
+import { makeTempHome } from './helpers.mjs';
+
+const SAMPLE = `# Refactor: zero-deps + .mjs (match codex-plugin-cc pattern)
+
+## Context
+
+Plugin works but has four runtime deps and a build step. User wants the
+codex shape.
+
+## Approach
+
+Drop TypeScript. Replace deps. No build.
+
+## File-by-file change list
+
+- plugins/cursor/scripts/delegate.ts → delegate.mjs
+- plugins/cursor/scripts/lib/jobs.ts → jobs.mjs
+
+## Verification
+
+1. \`npm test\` → 43/43 green.
+2. \`/cursor:setup --doctor\` prints OK.
+
+## Effort / risks
+
+~90 minutes. Risk: hand-rolled arg parser edge cases.
+`;
+
+describe('splitSections', () => {
+  it('pulls the title and each ## block', () => {
+    const { title, sections } = splitSections(SAMPLE);
+    expect(title).toBe('Refactor: zero-deps + .mjs (match codex-plugin-cc pattern)');
+    expect(Object.keys(sections)).toEqual(
+      expect.arrayContaining([
+        'context',
+        'approach',
+        'file-by-file change list',
+        'verification',
+        'effort / risks',
+      ]),
+    );
+    expect(sections['context']).toContain('build step');
+    expect(sections['verification']).toContain('npm test');
+  });
+});
+
+describe('slugify', () => {
+  it('kebabs lowercase, drops punctuation', () => {
+    expect(slugify('Refactor: zero-deps + .mjs')).toBe('refactor-zero-deps-mjs');
+    expect(slugify('')).toBe('plan');
+    expect(slugify('ahoj prosím projdi @tasks/30-i18n.md je to ok?')).toMatch(/^[a-z0-9-]+$/);
+  });
+
+  it('truncates to 50 chars', () => {
+    const long = 'a'.repeat(200);
+    expect(slugify(long).length).toBeLessThanOrEqual(50);
+  });
+});
+
+describe('buildTaskContent', () => {
+  it('includes all five task sections, dropping dev commentary', () => {
+    const plan = {
+      path: '/tmp/plan.md',
+      title: 'Refactor X',
+      slug: 'refactor-x',
+      sections: splitSections(SAMPLE).sections,
+      raw: SAMPLE,
+    };
+    const out = buildTaskContent(plan);
+    expect(out).toContain('# Refactor X');
+    expect(out).toContain('## Goal');
+    expect(out).toContain('## Repo context');
+    expect(out).toContain('## Acceptance criteria');
+    expect(out).toContain('## Files to touch');
+    expect(out).toContain('## How to verify');
+    expect(out).toContain('## Constraints');
+    expect(out).toContain('> Generated from Claude Code plan: `/tmp/plan.md`');
+    // Dev-only sections should NOT be copied across.
+    expect(out).not.toContain('Effort / risks');
+  });
+
+  it('degrades gracefully when sections are missing', () => {
+    const plan = {
+      path: '/tmp/bare.md',
+      title: 'Bare plan',
+      slug: 'bare-plan',
+      sections: { context: 'just this.' },
+      raw: '# Bare plan\n\n## Context\n\njust this.\n',
+    };
+    const out = buildTaskContent(plan);
+    expect(out).toContain('Bare plan');
+    expect(out).toContain('just this.');
+    expect(out).toContain('(no Approach');
+  });
+});
+
+describe('resolvePlanPath + parsePlanFile against a temp plans dir', () => {
+  let tmp;
+  let plansDir;
+  const prevHome = process.env.HOME;
+
+  beforeEach(() => {
+    tmp = makeTempHome();
+    plansDir = join(tmp.dir, '.claude', 'plans');
+    mkdirSync(plansDir, { recursive: true });
+    writeFileSync(join(plansDir, 'old-one.md'), '# Old\n\n## Context\n\nolder.', 'utf8');
+    // Bump mtime apart so ordering is deterministic.
+    const newPath = join(plansDir, 'brand-new-plan.md');
+    writeFileSync(newPath, SAMPLE, 'utf8');
+    const future = new Date(Date.now() + 5_000);
+    utimesSync(newPath, future, future);
+  });
+
+  afterEach(() => {
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    tmp.cleanup();
+  });
+
+  it('listPlans orders newest first', () => {
+    const plans = listPlans(plansDir);
+    expect(plans[0].name).toBe('brand-new-plan.md');
+  });
+
+  it('resolvePlanPath matches by name fragment', () => {
+    expect(resolvePlanPath('old', plansDir)).toContain('old-one.md');
+    expect(resolvePlanPath('brand', plansDir)).toContain('brand-new-plan.md');
+    expect(resolvePlanPath('does-not-exist', plansDir)).toBeUndefined();
+  });
+
+  it('resolvePlanPath picks the newest when ref is undefined', () => {
+    expect(resolvePlanPath(undefined, plansDir)).toContain('brand-new-plan.md');
+  });
+
+  it('parsePlanFile returns title + sections', () => {
+    const parsed = parsePlanFile(join(plansDir, 'brand-new-plan.md'));
+    expect(parsed.title).toContain('Refactor');
+    expect(parsed.slug).toMatch(/^refactor-/);
+    expect(parsed.sections['context']).toContain('build step');
+  });
+});


### PR DESCRIPTION
## Summary

- New **`/cursor:from-plan`** command that takes a Claude Code plan file (`~/.claude/plans/<slug>.md`) and rewrites it as a Cursor-shaped task file at `tasks/<YYYYMMDD-HHmm>-<slug>.md`, then optionally auto-invokes `/cursor:delegate`.
- Closes the plan→execute loop without manual copy/paste:
  ```
  /plan add dark-mode toggle
  /cursor:from-plan --delegate --model opus
  ```
- Plan version bumped to `0.2.0`. README has a new "Bonus: plan mode → /cursor:from-plan → delegate" subsection under the workflow recipe.

## Test plan

- [x] `npm test` — 52/52 specs green (9 new in `tests/plan.test.mjs`).
- [x] `npm run lint` — clean.
- [x] Smoke: `node scripts/from-plan.mjs -- --list` prints newest plan files.
- [x] Smoke: `node scripts/from-plan.mjs -- iridescent` writes a task file with all five standard sections, links back to the source plan.
- [x] Graceful degradation: missing sections show `(no Approach...)` instead of crashing.
- [ ] CI green on Node 18.18 / 20 / 22 × Ubuntu / macOS.

## Notes

- Parser is lenient: plans have free-form Markdown shape, we match section keywords like Context/Background, Approach/Plan/Implementation, File-by-file/Files/Critical files, Verification/How to verify/Test plan.
- Dev-only sections (`## Effort / risks`, `## Scope exclusions`) are intentionally dropped — the target repo's Cursor agent does not need them.
- `--delegate` / `--yes` switches from preview mode to auto-handoff; uses the same `@path` convention Claude Code uses to inline file content into prompts.