### PR TITLE
docs: v0.2.1 OSS ergonomics (AGENTS, CONTRIBUTING, SECURITY, templates, troubleshooting)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,97 @@
+name: Bug report
+description: Something in cursor-plugin-cc is broken.
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting. Please fill in the boxes below — most bugs need all of them to triage.
+
+  - type: input
+    id: node-version
+    attributes:
+      label: Node version
+      description: Output of `node --version`.
+      placeholder: v20.11.0
+    validations:
+      required: true
+
+  - type: input
+    id: cursor-agent-version
+    attributes:
+      label: cursor-agent version
+      description: Output of `cursor-agent --version`. If you don't have `cursor-agent` installed, say so.
+      placeholder: 2026.04.17-479fd04
+    validations:
+      required: true
+
+  - type: input
+    id: plugin-version
+    attributes:
+      label: Plugin version
+      description: Tag or commit. From the plugin cache `cat ~/.claude/plugins/cache/tomas-cursor/cursor/*/plugin.json | grep version`.
+      placeholder: v0.2.0
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: OS
+      options:
+        - macOS
+        - Linux
+        - Windows (WSL)
+        - Windows (native)
+    validations:
+      required: true
+
+  - type: textarea
+    id: doctor
+    attributes:
+      label: Output of `/cursor:setup --doctor`
+      description: Paste the full block. Mask the CURSOR_API_KEY if it is shown.
+      render: markdown
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Exact slash commands you ran, in order.
+      placeholder: |
+        1. `/cursor:delegate "write a haiku"`
+        2. Got this error: …
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-vs-actual
+    attributes:
+      label: What you expected vs. what happened
+      placeholder: |
+        Expected: job completes with a summary.
+        Actual: crashed with `Cannot find module`.
+    validations:
+      required: true
+
+  - type: input
+    id: job-id
+    attributes:
+      label: Job id (if the failure was inside /cursor:delegate or /cursor:browser)
+      description: From `/cursor:status` — we'll ask for the raw log at `~/.cursor-plugin-cc/jobs/<repo-hash>/logs/<job-id>.ndjson` if needed.
+      placeholder: XUE20Qpnu2
+
+  - type: textarea
+    id: raw-log
+    attributes:
+      label: Raw log excerpt (optional)
+      description: If you can paste the first ~50 lines of the job's `.ndjson`, it saves a round-trip. Remove anything sensitive first.
+      render: json
+
+  - type: textarea
+    id: anything-else
+    attributes:
+      label: Anything else
+      description: Workarounds you tried, screenshots, environment quirks, etc.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Cursor CLI issues
+    url: https://cursor.com/support
+    about: Problems with `cursor-agent` itself (auth, model availability, MCP servers) belong with Cursor, not here.
+  - name: Claude Code issues
+    url: https://github.com/anthropics/claude-code
+    about: Problems with the slash-command / plugin machinery itself (not this plugin's commands) belong upstream.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,54 @@
+name: Feature request
+description: Propose a new slash command, flag, or behaviour.
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before opening this, skim the [Roadmap section of the README](../blob/main/README.md#roadmap) and the existing [feature requests](https://github.com/freema/cursor-plugin-cc/issues?q=is%3Aissue+label%3Aenhancement) — your idea might already be there.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve
+      description: Describe the friction, not a solution yet. What did you try to do, what got in the way?
+      placeholder: |
+        "I want to re-run a failed delegate with the same prompt but a different model.
+         Right now I copy the prompt from /cursor:result and re-type /cursor:delegate --model opus."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed command / flag / behaviour
+      description: Sketch it. Name, flags, expected output. Rough is fine.
+      placeholder: |
+        /cursor:retry [job-id] [--model <id>] [--fresh]
+        Re-runs the same prompt. Defaults to the latest job if no id is given.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives you considered
+      description: What existing commands or workflows did you rule out, and why?
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Does it fit zero-deps + no-build?
+      description: See AGENTS.md. New runtime deps are a non-starter; new build steps too.
+      options:
+        - Yes — pure stdlib inside a new .mjs
+        - Not sure — need to discuss
+        - No — requires a dependency (explain below)
+    validations:
+      required: true
+
+  - type: textarea
+    id: anything-else
+    attributes:
+      label: Anything else
+      description: Sketches, related prior art (codex-plugin-cc, etc.), willingness to submit a PR.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Summary
+
+<!-- One paragraph: what changes, why. Link any issue this closes. -->
+
+## Test plan
+
+<!-- What you ran locally. Check what applies, add more lines if needed. -->
+
+- [ ] `npm test` — all specs green
+- [ ] `npm run lint` — prettier + eslint clean
+- [ ] Smoke-tested affected commands locally (describe how)
+- [ ] Docs updated (`README.md`, `AGENTS.md`, `CONTRIBUTING.md`, `CHANGELOG.md`) when relevant
+- [ ] New tests added for new behaviour (or N/A and justified)
+
+## Checklist
+
+- [ ] No new runtime dependencies (see `AGENTS.md`)
+- [ ] No build step, no new `dist/` or `.ts` files
+- [ ] `$ARGUMENTS` is quoted in any new / edited `commands/*.md`
+- [ ] New slash command (if any) follows the recipe in `CONTRIBUTING.md`
+- [ ] User-visible behaviour change is noted under `## Unreleased` in `CHANGELOG.md`

--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,5 @@ coverage/
 
 # Claude Code per-developer settings
 .claude/settings.local.json
+
+tasks/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,56 @@
+# AGENTS.md — rules for any AI agent editing this repo
+
+This file is the contract any agent (Claude Code, Cursor, Codex, …) must follow before touching code in `cursor-plugin-cc`. If you are human, read it too.
+
+## What this repo is
+
+A Claude Code plugin that delegates coding tasks from Claude to the Cursor CLI (`cursor-agent`). Nine slash commands under the `cursor:` namespace plus a `cursor-runner` subagent. Source of truth lives under `plugins/cursor/`.
+
+## Hard rules
+
+1. **Zero runtime dependencies.** The plugin ships as plain ESM `.mjs` and must execute directly after `/plugin install` with zero `npm install` in the user's plugin cache. If you are about to add `execa`, `zod`, `nanoid`, a HTTP client, a command parser, or any other third-party runtime package — stop. Write a small inline helper instead. See `plugins/cursor/scripts/lib/run.mjs` as the reference pattern (it replaced `execa` in ~80 lines).
+2. **No build step.** No TypeScript, no bundler, no `dist/`. `scripts/*.mjs` IS the ship artefact. If you find yourself wanting one, something has gone wrong with the approach.
+3. **Slash command scripts live under `plugins/cursor/scripts/<cmd>.mjs`.** Their wrappers at `plugins/cursor/commands/<cmd>.md` must use `node "${CLAUDE_PLUGIN_ROOT}/scripts/<cmd>.mjs" -- "$ARGUMENTS"` with quoted `$ARGUMENTS` — unquoted breaks under zsh on any prompt containing `?`, `*`, or `@`.
+4. **`Bash(node:*)` is the only permission pattern used in `allowed-tools`.** Do not invent path-based patterns — Claude Code does not expand `${CLAUDE_PLUGIN_ROOT}` inside `allowed-tools`.
+5. **Jobs are persisted under `~/.cursor-plugin-cc/jobs/<repo-hash>/`.** Never break that layout; users point scripts at those files when reporting bugs.
+6. **Language: everything in this repo is English.** Code, comments, commit messages, docs, PR bodies, issue titles. The plugin does not impose a language policy on target repos — `cursor-runner` reads target-repo conventions — but this repo itself is English-only.
+7. **Do not impose conventions on target repos.** The `cursor-runner` subagent reads `AGENTS.md` / `.cursor/rules` / existing code in whatever repo the user is working in and tells Cursor to match THAT style. When editing the subagent, do not hardcode English / Prettier / whatever.
+
+## Task format
+
+Every delegated task (whether you write it by hand or `/cursor:from-plan` generates it) uses five sections in this order:
+
+1. **Goal** — one sentence.
+2. **Repo context** — stack + pointer to AGENTS.md / `.cursor/rules` / conventions file.
+3. **Acceptance criteria** — 1–5 verifiable bullets.
+4. **Files to touch** — explicit list when predictable.
+5. **How to verify** — exact commands (`npm test`, `task typecheck`, etc.).
+
+Plus a **Constraints** block that forbids: touching files outside the list, renaming public APIs, modifying lockfiles.
+
+## How to make a change
+
+1. Branch named `feat/…`, `fix/…`, `refactor/…`, or `docs/…`.
+2. Work inside `plugins/cursor/`. `cd plugins/cursor && npm install` installs dev deps (vitest, eslint, prettier — the only ones).
+3. Run tests: `npm test`. Run lint: `npm run lint`. Both must be green before committing.
+4. Commit messages in conventional style (`type(scope): subject`).
+5. Open a PR against `main` with a summary + test plan. CI must pass across Node 18.18 / 20 / 22 × Ubuntu / macOS.
+6. Squash-merge only.
+
+## Guardrails for automated edits
+
+- Do not touch `package-lock.json` unless you are changing dependencies on purpose.
+- Do not modify `~/.cursor-plugin-cc/jobs/**` — that is user state, never ours.
+- Do not rename the command namespace (`cursor:`) or the marketplace name (`tomas-cursor`) without explicit user approval — both are referenced in user environments.
+- When adding a new slash command, follow the recipe in `CONTRIBUTING.md`.
+
+## Where things live
+
+- `plugins/cursor/scripts/<cmd>.mjs` — command entrypoints (9).
+- `plugins/cursor/scripts/lib/*.mjs` — shared helpers (run, id, args, paths, jobs, parse, cursor, git, invoked, plan).
+- `plugins/cursor/commands/*.md` — slash command wrappers.
+- `plugins/cursor/agents/cursor-runner.md` — the handoff subagent prompt.
+- `plugins/cursor/tests/*.test.mjs` — vitest specs + fixtures.
+- `.claude-plugin/marketplace.json` — what Claude Code's `/plugin install` reads.
+
+If you are about to add a file outside these paths, justify it in the PR description.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.1 — OSS ergonomics (docs-only)
+
+### Added
+
+- `AGENTS.md` at repo root — hard rules any AI agent (Claude Code, Cursor, Codex) must follow when editing this repo. Dogfoods the same pattern `cursor-runner` tells agents to read in target repos.
+- `CONTRIBUTING.md` — dev setup, branch naming, commit-message conventions, step-by-step recipe for adding a new slash command, and the release flow.
+- `SECURITY.md` — vulnerability reporting, the `--force`/`--trust` trade-offs the user should understand, and the zero-deps supply-chain stance.
+- `.github/ISSUE_TEMPLATE/bug_report.yml` and `feature_request.yml` — structured forms that capture Node / cursor-agent / plugin version, `/cursor:setup --doctor` output and job id up-front.
+- `.github/PULL_REQUEST_TEMPLATE.md` — summary + test plan + zero-deps checklist.
+- README: new **Troubleshooting** section covering the six failure modes that tripped us during development (reload-plugins, shell globbing, module-not-found, Bash permission, browser MCP not loaded, from-plan empty).
+
+### Changed
+
+- README "Contributing" shrunk to a pointer toward the new dedicated files so the homepage stays scannable.
+
 ## 0.2.0 — plan-mode bridge + zero-deps rewrite
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,117 @@
+# Contributing to cursor-plugin-cc
+
+Thanks for looking. This is a small plugin; contributions are welcome.
+
+## Before you start
+
+Read [`AGENTS.md`](./AGENTS.md) at the repo root — it spells out the hard rules (zero runtime deps, no build step, etc.). If your change would break one of them, open an issue first.
+
+## Dev setup
+
+```bash
+git clone https://github.com/freema/cursor-plugin-cc
+cd cursor-plugin-cc/plugins/cursor
+npm install    # installs only dev deps: vitest, eslint, prettier, @eslint/js
+npm test
+npm run lint
+```
+
+No build, no bundler. `scripts/*.mjs` runs directly via `node`. If `node_modules/` needed in the install step surprised you, that is only for running tests and the formatter; the shipped plugin itself needs zero dependencies.
+
+## Branch naming
+
+- `feat/<slug>` — new user-visible feature or command.
+- `fix/<slug>` — bug fix.
+- `refactor/<slug>` — internal reshape, no user impact.
+- `docs/<slug>` — docs only.
+- `ci/<slug>` — CI or tooling.
+
+Keep branches focused. One feature or fix per PR.
+
+## Commit messages
+
+Conventional-commits style:
+
+```
+feat(browser): auto-discover localhost port from vite.config
+fix(delegate): quote $ARGUMENTS so zsh doesn't glob ?
+refactor: drop esbuild, ship .mjs directly
+docs(readme): add troubleshooting section
+```
+
+One short subject line, imperative mood, optional body explaining the **why**.
+
+## PR process
+
+1. Push your branch.
+2. Open a PR against `main`. The PR template asks for a summary and a test plan — fill both.
+3. CI runs the test matrix (Node 18.18 / 20 / 22 × Ubuntu / macOS). All six must pass.
+4. The maintainer reviews, suggests changes, or merges. **Squash merge** is the default.
+5. No direct pushes to `main` — branch protection enforces PR review.
+
+## How to add a new slash command
+
+The plugin has a consistent recipe. Follow it exactly for any new command — reviewers will bounce anything that deviates without explanation.
+
+### Checklist
+
+1. **Pick a name.** Keep it short and under the `cursor:` namespace (e.g. `/cursor:diff`, `/cursor:retry`). Verbs preferred.
+2. **Write `plugins/cursor/scripts/<cmd>.mjs`.**
+   - Starts with `#!/usr/bin/env node`.
+   - Imports `parseArgv`, `collapseArguments` from `./lib/args.mjs`.
+   - Exports `async function main(rawArgv): Promise<number>` returning the exit code.
+   - Uses `invokedAsScript(import.meta.url)` from `./lib/invoked.mjs` for the "am I the entry point?" guard.
+   - Writes **structured Markdown** to stdout so Claude Code renders it. Stick to bullet lists, tables, and fenced code blocks — nothing Claude has to paraphrase.
+   - Writes errors to stderr; return code 2 for bad input, 1 for runtime failure, 0 for success.
+3. **Write `plugins/cursor/commands/<cmd>.md`.**
+   - Frontmatter: `description`, `argument-hint`, `allowed-tools: Bash(node:*)`.
+   - Body: `!` + a single line `` `node "${CLAUDE_PLUGIN_ROOT}/scripts/<cmd>.mjs" -- "$ARGUMENTS"` `` (quotes around `$ARGUMENTS` are mandatory — zsh will glob otherwise).
+   - Add a one-paragraph note telling Claude Code how to render the output (usually "verbatim, do not paraphrase").
+4. **Write `plugins/cursor/tests/<cmd>.test.mjs`.**
+   - Import `main` from `../scripts/<cmd>.mjs`.
+   - Use the stub `cursor-agent` binary (`tests/fixtures/cursor-agent-stub.mjs`) via `CURSOR_AGENT_BIN` env and a fixture NDJSON.
+   - Spy on `process.stdout.write` and `process.stderr.write` to assert output without polluting the test runner.
+   - Cover: happy path, bad input (exit 2), empty env (graceful degradation).
+5. **Update `plugins/cursor/package.json`'s `scripts`** with a `"<cmd>": "node scripts/<cmd>.mjs"` alias so maintainers can run it via `npm run <cmd>`.
+6. **Update the README:**
+   - Add it to the "What you get" bullet list at the top.
+   - Add a `### /cursor:<cmd>` subsection under **Usage** explaining flags + 2 example invocations.
+7. **Update `CHANGELOG.md`** under the `## Unreleased` → `### Added` section.
+
+### Don'ts
+
+- **Don't add runtime deps.** If the command needs behaviour you would normally pull a library for, write 30 lines in `lib/` instead. See `lib/run.mjs` (execa replacement) and `lib/args.mjs` (yargs-parser replacement) for the shape.
+- **Don't introduce `dist/`, `build.mjs`, or any TypeScript file.** The source IS the ship artefact.
+- **Don't bypass `lib/run.mjs`.** Every external command invocation goes through it so timeouts and exit-code handling stay consistent.
+- **Don't hardcode `~` or `os.homedir()` directly.** Use `lib/paths.mjs` — it honours the `CURSOR_PLUGIN_CC_HOME` env override (test suites rely on this).
+
+## Running against real cursor-agent
+
+Tests use a stub binary that replays NDJSON fixtures. To smoke-test against the real CLI:
+
+```bash
+CURSOR_AGENT_BIN=/path/to/cursor-agent node plugins/cursor/scripts/setup.mjs --doctor
+node plugins/cursor/scripts/delegate.mjs --no-git-check -- "write a short haiku about git"
+```
+
+This spends real Cursor tokens, so keep it to trivial tasks during development.
+
+## Reporting bugs
+
+Use the GitHub issue template. Include:
+
+- `node --version`, `cursor-agent --version`
+- Output of `/cursor:setup --doctor`
+- For `/cursor:delegate` or `/cursor:browser` failures: the job id from `/cursor:status` and the path of the raw log under `~/.cursor-plugin-cc/jobs/<hash>/logs/<id>.ndjson`.
+
+## Release flow
+
+Maintainer-only, reference:
+
+1. Ensure `CHANGELOG.md` has a `## x.y.z — …` section with Added/Changed/Fixed bullets moved out of `## Unreleased`.
+2. Bump `version` in `plugins/cursor/package.json` and `plugins/cursor/plugin.json` to match.
+3. Merge a `release/x.y.z` branch to `main` via PR.
+4. `git tag -a vX.Y.Z -m "vX.Y.Z — headline"` + `git push origin vX.Y.Z`.
+5. `gh release create vX.Y.Z --title "vX.Y.Z — headline" --notes-file <release-notes.md>`.
+
+No automated publish pipeline yet — by design, see roadmap.

--- a/README.md
+++ b/README.md
@@ -323,23 +323,59 @@ This re-opens the same Cursor session without going through Claude Code — hand
 
 **`cursor-agent` hangs after finishing a task.** Known quirk of the print-mode CLI. The plugin has a 5-second watchdog that SIGTERMs the process after a `result` event if it hasn't self-exited, then SIGKILLs 5 seconds later.
 
+## Troubleshooting
+
+Things that bit users (and us) during development, with the exact fix each time.
+
+### `Unknown command: /cursor:setup`
+
+You skipped `/reload-plugins`. Claude Code only picks up newly-installed plugin commands after a reload — `/plugin install` alone is not enough. Run `/reload-plugins` and the commands appear.
+
+### `Shell command failed for pattern ... no matches found: review?`
+
+Zsh globbing on `?` or `*` in your prompt. This should not happen in `v0.2.0+` because every command wrapper quotes `"$ARGUMENTS"`. If you see it, your plugin is outdated — reinstall: `/plugin marketplace remove tomas-cursor && /plugin marketplace add freema/cursor-plugin-cc && /plugin install cursor@tomas-cursor && /reload-plugins`.
+
+### `Error: Cannot find module '.../dist/<cmd>.js'` or `'.../scripts/<cmd>.mjs'`
+
+Stale plugin cache from an older version. Same fix as above: remove marketplace, re-add, re-install, reload.
+
+### `Shell command permission check failed for pattern "!node ..."`
+
+First-time Bash permission prompt. Approve `node` for this session (Claude Code asks once per session; the approval covers all plugin commands since all of them invoke `node`). If you denied it accidentally, `/permissions` lets you review/change.
+
+### `/cursor:browser` says "The run never called the `chrome-devtools` MCP"
+
+The MCP server is not loaded in the current `cursor-agent` process. Three common causes:
+
+1. **Not approved.** Run `cursor-agent mcp enable chrome-devtools` (or use `--approve-mcps` which `/cursor:browser` already passes).
+2. **Not configured in `~/.cursor/mcp.json`.** Add the entry the error message suggests, including `--isolated` in the args to avoid Chrome profile lockouts.
+3. **Cursor not restarted after editing `mcp.json`.** Cursor caches MCP config at startup; a restart is required.
+
+Verify with `/cursor:setup --doctor` → the "Configured Cursor MCPs" section should list `chrome-devtools` with status `loaded` (or at least `approved`).
+
+### `/cursor:from-plan` says "no plan files found"
+
+Claude Code only writes plan files when you explicitly enter plan mode and then exit it with approval. If you never did that, there is nothing to convert. Enter plan mode (`/plan ...`) first; run `/cursor:from-plan --list` afterwards to confirm the file is there.
+
+### `cursor-agent` hangs mid-run
+
+Usually Cursor's backend, not us. The plugin has a default 30-minute timeout (`--timeout 1800`). For long tasks, bump it with `--timeout 3600`. For stuck jobs, `/cursor:cancel <id>` — SIGTERM with a 5 s grace window, then SIGKILL.
+
+### `/cursor:delegate` prints `Error: current directory is not a git repository`
+
+Safety check: by default the plugin refuses to run outside a git repo so Cursor cannot modify an unversioned tree. Pass `--no-git-check` if you know what you are doing.
+
+### Logs and raw output
+
+Every job writes its full `cursor-agent` NDJSON stream to `~/.cursor-plugin-cc/jobs/<repo-hash>/logs/<job-id>.ndjson`. When reporting bugs, include the first ~50 lines of the relevant log (after scrubbing anything sensitive).
+
 ## Contributing
 
 Plugin users can skip this section — there is nothing to build.
 
-For hacking on the plugin itself, clone and work inside `plugins/cursor/`:
+Contributors, read [`CONTRIBUTING.md`](./CONTRIBUTING.md) for the dev setup, branch naming, the "how to add a new slash command" recipe, and the release flow. The hard rules (zero runtime deps, no build step, etc.) live in [`AGENTS.md`](./AGENTS.md) — the same file `cursor-runner` tells Cursor to read before touching any repo. Reporting a vulnerability? See [`SECURITY.md`](./SECURITY.md).
 
-```bash
-git clone https://github.com/freema/cursor-plugin-cc
-cd cursor-plugin-cc/plugins/cursor
-npm install    # only dev deps: vitest, eslint, prettier
-npm test
-npm run lint
-```
-
-The source **is** the ship artefact — `scripts/*.mjs` files are what Claude Code executes in the user's cache. No bundler, no compile step. If you add a runtime dependency, you are on the wrong plugin. Keep the surface zero-dep: replace third-party helpers with small inline stdlib-based equivalents (see `scripts/lib/run.mjs` as the pattern — it replaced `execa`).
-
-CI runs `npm test` and `npm run lint` on every PR across Node 18.18 / 20 / 22 on Ubuntu + macOS.
+CI runs `npm test` and `npm run lint` on every PR across Node 18.18 / 20 / 22 on Ubuntu + macOS. No direct pushes to `main` — branch protection enforces PR review.
 
 ## Roadmap
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security policy
+
+## Reporting a vulnerability
+
+If you find a security issue — credential leak, command injection, path traversal, anything that lets a malicious input do something the user did not intend — please **do not open a public issue**.
+
+Report privately via [GitHub Security Advisories](https://github.com/freema/cursor-plugin-cc/security/advisories/new) or by email to `tomas.grasl@metrifyr.cloud`. Expect a response within a week. Once a fix is merged we will publish an advisory with credit (unless you prefer anonymity).
+
+## Supported versions
+
+Only the latest tagged release on `main` is supported. Run `/cursor:setup --doctor` to see what you have; upgrade via `/plugin marketplace remove tomas-cursor && /plugin marketplace add freema/cursor-plugin-cc && /plugin install cursor@tomas-cursor && /reload-plugins`.
+
+## Known trade-offs the user should understand
+
+- **`--force` is on by default.** Every `/cursor:delegate` invocation passes `--force` (alias `--yolo`) to `cursor-agent`. That means Cursor will auto-apply file writes and run commands without prompting for each one. This is necessary for non-interactive use but it also means a poorly-scoped task can touch files outside what you intended. Use `--no-force` when running against code you do not fully control.
+- **`--trust` is always on.** Required by `cursor-agent` in headless mode to bypass the workspace-trust prompt. Do not point the plugin at repositories you do not already trust.
+- **`--approve-mcps` is set on `/cursor:browser`.** MCP servers configured in your `~/.cursor/mcp.json` get loaded automatically for that command. Only configure MCPs you trust.
+- **Cursor's backend receives your prompts and repo context.** The plugin is a thin wrapper around `cursor-agent`. All data-handling commitments are Cursor's, not this plugin's.
+- **Job logs under `~/.cursor-plugin-cc/jobs/<repo-hash>/` contain the full `cursor-agent` stream-json output.** That may include snippets of your source code or environment metadata. Treat the directory as sensitive; we do not upload it anywhere, but local access controls are your responsibility.
+
+## Non-goals
+
+This plugin is not a sandbox. If you need stronger isolation, use `cursor-agent --sandbox enabled` manually (we expose it via a flag in a future release — see Roadmap) or run the whole thing in a container.
+
+## Supply-chain stance
+
+- **Zero runtime dependencies.** `/plugin install` unpacks only what git ships — no `npm install` runs in the user's plugin cache. This is a deliberate choice to keep the supply-chain surface at zero (see `AGENTS.md`).
+- Dev dependencies (`vitest`, `eslint`, `prettier`, `@eslint/js`) run only on the maintainer's machine and in CI. They are pinned in `plugins/cursor/package-lock.json` and upgraded manually, not by Dependabot.
+- No `postinstall` scripts, no `prepare` hook, no `preinstall` — nothing runs when the plugin is installed into a user's Claude Code cache.

--- a/plugins/cursor/package.json
+++ b/plugins/cursor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cursor-plugin-cc",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Use Cursor CLI from Claude Code to delegate coding tasks to Composer 2 and other Cursor models.",
   "type": "module",
   "license": "MIT",

--- a/plugins/cursor/plugin.json
+++ b/plugins/cursor/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cursor",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Hand off tasks from Claude Code to cursor-agent. Composer 2 optimised.",
   "author": {
     "name": "Tomas Grasl",


### PR DESCRIPTION
## Summary

No code changes. Fills the documentation and project-infrastructure gaps a small public repo needs.

## Added

- **`AGENTS.md`** — hard rules for any AI agent editing this repo. Dogfoods the pattern `cursor-runner` tells agents to read in target repos.
- **`CONTRIBUTING.md`** — dev setup, branch naming, commit conventions, "how to add a new slash command" recipe, release flow.
- **`SECURITY.md`** — vulnerability reporting, the `--force` / `--trust` / `--approve-mcps` trade-offs, zero-deps supply-chain stance.
- **`.github/ISSUE_TEMPLATE/bug_report.yml`** + **`feature_request.yml`** + **`config.yml`** — structured forms, upstream redirects for Cursor / Claude-Code issues.
- **`.github/PULL_REQUEST_TEMPLATE.md`** — summary + test plan + zero-deps checklist.
- **README Troubleshooting section** — the six failure modes we hit during development, each with the exact fix.

## Changed

- README Contributing trimmed to a pointer toward the new dedicated files.
- Plugin version bumped to `0.2.1`.

## Test plan

- [x] `npm test` — 52/52 green (no code touched, but ran it to confirm).
- [x] `npm run lint` — clean.
- [x] README renders on GitHub with correct cross-links to `AGENTS.md`, `CONTRIBUTING.md`, `SECURITY.md`.
- [ ] CI green on Node 18.18 / 20 / 22 × Ubuntu / macOS.