### PR TITLE
fix(cursor-runner): correct stale delegate invocation in agent doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- **`cursor-runner` agent invocation corrected.** Step 6 told the subagent to run `node_modules/.bin/tsx …/plugins/cursor/scripts/delegate.ts` — stale from before the zero-deps `.mjs` rewrite: `tsx` is not a dependency, there is no `.ts` file, and the path double-counted `plugins/cursor`. It now matches the working slash command: `node "${CLAUDE_PLUGIN_ROOT}/scripts/delegate.mjs" -- …`. The `/cursor:delegate` slash command was already correct; only the subagent's documented call was broken.
+
 ## 0.3.0 — /cursor:review + codebase hardening
 
 ### Added

--- a/plugins/cursor/agents/cursor-runner.md
+++ b/plugins/cursor/agents/cursor-runner.md
@@ -76,8 +76,7 @@ When in doubt: fresh if the task topic changed, resume if it's the same thread o
 ### 6. Invoke `/cursor:delegate` via a single `Bash` call
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT}/node_modules/.bin/tsx" \
-  "${CLAUDE_PLUGIN_ROOT}/plugins/cursor/scripts/delegate.ts" \
+node "${CLAUDE_PLUGIN_ROOT}/scripts/delegate.mjs" \
   -- --model fast "<prompt>"
 ```
 
@@ -97,7 +96,7 @@ Do not paraphrase the summary, do not rewrite the file list, do not hide the cha
 
 ## Output format
 
-Return exactly what `delegate.ts` prints. One line of your own framing is fine:
+Return exactly what `delegate.mjs` prints. One line of your own framing is fine:
 
 > Delegated to Cursor (`composer-2-fast`). Result below.
 


### PR DESCRIPTION
## Summary

The `cursor-runner` subagent's step 6 instructed it to invoke delegation via `node_modules/.bin/tsx …/plugins/cursor/scripts/delegate.ts` — stale from before the zero-deps `.mjs` rewrite: `tsx` is not a dependency, there is no `.ts` file, and the path double-counted `plugins/cursor`. So any delegation routed through the subagent (as opposed to the `/cursor:delegate` slash command, which is correct) failed if followed literally.

Replaced it with the invocation the slash command already uses — `node "${CLAUDE_PLUGIN_ROOT}/scripts/delegate.mjs" -- …` — and fixed the matching `delegate.ts` mention in the Output format section. Docs-only. Closes #10..

## Test plan

- [x] `npm test` — all specs green
- [x] `npm run lint` — prettier + eslint clean (agent doc is under `plugins/cursor`)
- [x] No code paths changed; verified the corrected command matches `commands/delegate.md`

## Checklist

- [x] No new runtime dependencies
- [x] No build step, no new `dist/` or `.ts` files
- [x] User-visible behaviour change noted under `## Unreleased` in `CHANGELOG.md`