### PR TITLE
fix(aliases): update gpt shorthand to gpt-5.5-high (was stale gpt-5.3-codex)

### DIFF
--- a/plugins/cursor/scripts/lib/cursor.mjs
+++ b/plugins/cursor/scripts/lib/cursor.mjs
@@ -32,7 +32,7 @@ export const MODEL_ALIASES = {
   'opus-4.7-max': 'claude-opus-4-7-max',
   'opus-4.7-thinking': 'claude-opus-4-7-thinking-high',
   'opus-4.6': 'claude-4.6-opus-high',
-  gpt: 'gpt-5.3-codex',
+  gpt: 'gpt-5.5-high',
   codex: 'gpt-5.3-codex',
   'gpt-5.3-codex': 'gpt-5.3-codex',
   'gpt-5.3-codex-fast': 'gpt-5.3-codex-fast',

--- a/plugins/cursor/tests/cursor.test.mjs
+++ b/plugins/cursor/tests/cursor.test.mjs
@@ -59,7 +59,7 @@ describe('resolveModel', () => {
     expect(resolveModel('composer-2.5-fast')).toBe('composer-2.5-fast');
     expect(resolveModel('sonnet')).toBe('claude-4.6-sonnet-medium');
     expect(resolveModel('opus')).toBe('claude-opus-4-7-high');
-    expect(resolveModel('gpt')).toBe('gpt-5.3-codex');
+    expect(resolveModel('gpt')).toBe('gpt-5.5-high');
     expect(resolveModel('grok')).toBe('grok-4.3');
     expect(resolveModel('grok-build')).toBe('grok-build-0.1');
     expect(resolveModel('gemini')).toBe('gemini-3.1-pro');


### PR DESCRIPTION
## Summary

The bare `gpt` alias in `MODEL_ALIASES` pointed to `gpt-5.3-codex`, which is two major versions behind the latest GPT model in the alias table (`gpt-5.5-high`).

- Updated `gpt` → `gpt-5.5-high`
- Updated the corresponding test expectation

## Why it matters

When users pass `--model gpt` (or a skill invokes the review/delegate script with the `gpt` shorthand), they expect the latest GPT model, not a stale one two generations old. This caused a user to get `gpt-5.3-codex` when they explicitly asked for "latest gpt".

🤖 Generated with [Claude Code](https://claude.com/claude-code)