### PR TITLE
fix(jobs): kill the whole process group on /cursor:cancel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ Plus a **Constraints** block that forbids: touching files outside the list, rena
 ## Where things live
 
 - `plugins/cursor/scripts/<cmd>.mjs` — command entrypoints (10; `adversarial-review` has no script of its own — it reuses `review.mjs --adversarial`).
-- `plugins/cursor/scripts/lib/*.mjs` — shared helpers (run, id, args, paths, jobs, parse, cursor, git, invoked, plan, hints, md).
+- `plugins/cursor/scripts/lib/*.mjs` — shared helpers (run, id, args, paths, jobs, kill, parse, cursor, git, invoked, plan, hints, md).
 - `plugins/cursor/commands/*.md` — slash command wrappers.
 - `plugins/cursor/agents/cursor-runner.md` — the handoff subagent prompt.
 - `plugins/cursor/skills/composer-prompting/SKILL.md` — Cursor prompt-shaping guidance the `cursor-runner` subagent references via its `skills:` frontmatter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- **`/cursor:cancel` no longer orphans the running `cursor-agent`.** Background jobs run as a detached worker (its own process group) that spawns `cursor-agent` as a child. Cancelling signalled only the worker pid, so the worker died but `cursor-agent` kept running — still editing files and consuming Cursor credits — while `/cursor:status` reported the job as `cancelled`. `cancelJob` now signals the worker's whole process group (SIGTERM, then SIGKILL after the grace period) via the new `lib/kill.mjs#killTree`, falling back to a single-pid kill for foreground jobs whose recorded pid is not a group leader. On Windows the tree is terminated with `taskkill /T /F`.
+
 ## 0.4.0 — /cursor:adversarial-review + estimate-first reviews + composer-prompting skill
 
 Ported from upstream [`openai/codex-plugin-cc`](https://github.com/openai/codex-plugin-cc) (whose `/codex:adversarial-review`, estimate-first review flow, and `gpt-5-4-prompting` skill this release mirrors), adapted to the Cursor CLI.

--- a/plugins/cursor/scripts/lib/jobs.mjs
+++ b/plugins/cursor/scripts/lib/jobs.mjs
@@ -8,6 +8,7 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { join } from 'node:path';
+import { killTree } from './kill.mjs';
 import { ensureDir, jobsDir, logsDir } from './paths.mjs';
 
 /**
@@ -225,25 +226,20 @@ export async function cancelJob(repoPath, id, graceMs = 5_000) {
   if (!job) return null;
   if (job.status !== 'running') return job;
   // NOTE: PIDs are recycled by the OS. If the original process already exited
-  // and its PID was reused, the signals below could hit an unrelated process.
-  // The job dir is short-lived and pruned after 30 days, so we accept this
-  // rather than track a process-group / start-time identity cross-platform.
+  // and its PID was reused, the signals below could hit an unrelated process
+  // (or, for a reused group-leader pid, its process group). The job dir is
+  // short-lived and pruned after 30 days, so we accept this rather than track
+  // a start-time identity cross-platform.
   if (typeof job.pid === 'number' && isProcessAlive(job.pid)) {
-    try {
-      process.kill(job.pid, 'SIGTERM');
-    } catch {
-      // ignore — may have exited
-    }
+    // killTree signals the worker's whole process group so the cursor-agent
+    // child dies too — see lib/kill.mjs for why plain kill(pid) is not enough.
+    killTree(job.pid, 'SIGTERM');
     const deadline = Date.now() + graceMs;
     while (Date.now() < deadline && isProcessAlive(job.pid)) {
       await new Promise((r) => setTimeout(r, 200));
     }
     if (isProcessAlive(job.pid)) {
-      try {
-        process.kill(job.pid, 'SIGKILL');
-      } catch {
-        // ignore
-      }
+      killTree(job.pid, 'SIGKILL');
     }
   }
   return updateJob(repoPath, id, {

--- a/plugins/cursor/scripts/lib/kill.mjs
+++ b/plugins/cursor/scripts/lib/kill.mjs
@@ -1,0 +1,43 @@
+// Signal a job's whole process tree, not just the pid we recorded.
+//
+// Background workers are spawned with `detached: true` (delegate.mjs /
+// review.mjs), which makes the worker the leader of a fresh process group;
+// the `cursor-agent` child it spawns inherits that group. Signalling only the
+// worker pid therefore orphans cursor-agent — it keeps editing files and
+// burning credits while /cursor:status claims the job is cancelled. Signalling
+// the group (`kill(-pid)`) reaches both.
+//
+// Foreground jobs record the delegate script's own pid, which is usually NOT
+// a group leader — for those the group kill fails with ESRCH and we fall back
+// to the single pid, which matches the old behaviour.
+
+import { spawnSync } from 'node:child_process';
+
+/**
+ * @param {number} pid
+ * @param {NodeJS.Signals} signal
+ * @returns {boolean} true if a signal was delivered to at least one process
+ */
+export function killTree(pid, signal) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  if (process.platform === 'win32') {
+    // Windows has no POSIX signals or process groups; `taskkill /T` walks the
+    // tree. `/F` because the graceful variant sends WM_CLOSE, which console
+    // apps ignore — there is no meaningful SIGTERM/SIGKILL distinction here.
+    const res = spawnSync('taskkill', ['/PID', String(pid), '/T', '/F'], { stdio: 'ignore' });
+    return res.status === 0;
+  }
+  try {
+    process.kill(-pid, signal);
+    return true;
+  } catch {
+    // No group with that pgid (ESRCH: pid is not a group leader) or the group
+    // could not be signalled — try the pid alone before giving up.
+    try {
+      process.kill(pid, signal);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/plugins/cursor/tests/helpers.mjs
+++ b/plugins/cursor/tests/helpers.mjs
@@ -10,6 +10,22 @@ export function makeTempHome() {
   };
 }
 
+export function isAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function waitForDeath(pid, timeoutMs = 3_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline && isAlive(pid)) {
+    await new Promise((r) => setTimeout(r, 50));
+  }
+}
+
 export const STUB_BIN = new URL('./fixtures/cursor-agent-stub.mjs', import.meta.url).pathname;
 export const HAPPY_FIXTURE = new URL('./fixtures/cursor-events/happy-path.ndjson', import.meta.url)
   .pathname;

--- a/plugins/cursor/tests/jobs.test.mjs
+++ b/plugins/cursor/tests/jobs.test.mjs
@@ -12,7 +12,7 @@ import {
   readJob,
   updateJob,
 } from '../scripts/lib/jobs.mjs';
-import { makeTempHome } from './helpers.mjs';
+import { isAlive, makeTempHome, waitForDeath } from './helpers.mjs';
 
 describe('jobs registry', () => {
   let tmp;
@@ -82,6 +82,60 @@ describe('jobs registry', () => {
       if (!child.killed) child.kill('SIGKILL');
     }
   });
+
+  it.skipIf(process.platform === 'win32')(
+    'cancelJob kills a detached worker AND its child (process group)',
+    async () => {
+      // Reproduce the background-delegate shape: spawnBackground() starts the
+      // worker with `detached: true` (own process group) and the worker spawns
+      // cursor-agent as a plain child (same group). Cancelling must reach BOTH
+      // — killing only the worker orphans the stand-in cursor-agent.
+      const workerScript = [
+        "const { spawn } = require('node:child_process');",
+        "const c = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { stdio: 'ignore' });",
+        'console.log(c.pid);',
+        'setInterval(() => {}, 1000);',
+      ].join('\n');
+      const worker = spawn(process.execPath, ['-e', workerScript], {
+        stdio: ['ignore', 'pipe', 'ignore'],
+        detached: true,
+      });
+      const childPid = await new Promise((resolve, reject) => {
+        let buf = '';
+        worker.stdout.on('data', (d) => {
+          buf += d;
+          const m = /^(\d+)\s/.exec(buf);
+          if (m) resolve(Number(m[1]));
+        });
+        worker.on('error', reject);
+        setTimeout(() => reject(new Error('worker never reported its child pid')), 5_000);
+      });
+      try {
+        createJob({ id: 'tree', repoPath: repo, prompt: 'p', model: 'm' });
+        updateJob(repo, 'tree', { pid: worker.pid });
+        const cancelled = await cancelJob(repo, 'tree', 2_000);
+        expect(cancelled?.status).toBe('cancelled');
+        await waitForDeath(worker.pid);
+        await waitForDeath(childPid);
+        expect(isAlive(worker.pid)).toBe(false);
+        expect(isAlive(childPid)).toBe(false);
+      } finally {
+        // Belt and braces: never leave the group behind on assertion failure.
+        for (const pid of [worker.pid, childPid]) {
+          try {
+            process.kill(-pid, 'SIGKILL');
+          } catch {
+            // noop
+          }
+          try {
+            process.kill(pid, 'SIGKILL');
+          } catch {
+            // noop
+          }
+        }
+      }
+    },
+  );
 
   it('cancelJob on unknown id returns null', async () => {
     const res = await cancelJob(repo, 'nope');

--- a/plugins/cursor/tests/kill.test.mjs
+++ b/plugins/cursor/tests/kill.test.mjs
@@ -1,0 +1,35 @@
+import { spawn } from 'node:child_process';
+import { describe, expect, it } from 'vitest';
+import { killTree } from '../scripts/lib/kill.mjs';
+import { isAlive, waitForDeath } from './helpers.mjs';
+
+describe('killTree', () => {
+  it('rejects non-positive and non-integer pids', () => {
+    expect(killTree(0, 'SIGTERM')).toBe(false);
+    expect(killTree(-42, 'SIGTERM')).toBe(false);
+    expect(killTree(1.5, 'SIGTERM')).toBe(false);
+    expect(killTree(NaN, 'SIGTERM')).toBe(false);
+  });
+
+  it('falls back to a single-pid kill for a non-group-leader', async () => {
+    // Spawned without `detached`, the child shares OUR process group, so the
+    // group kill inside killTree must fail with ESRCH and fall back — if it
+    // signalled the group, it would kill this test runner.
+    const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
+      stdio: 'ignore',
+    });
+    try {
+      expect(killTree(child.pid, 'SIGTERM')).toBe(true);
+      await waitForDeath(child.pid);
+      expect(isAlive(child.pid)).toBe(false);
+    } finally {
+      if (!child.killed) child.kill('SIGKILL');
+    }
+  });
+
+  it('returns false when nothing answers to the pid', async () => {
+    const child = spawn(process.execPath, ['-e', 'process.exit(0)'], { stdio: 'ignore' });
+    await new Promise((r) => child.on('exit', r));
+    expect(killTree(child.pid, 'SIGTERM')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

`/cursor:cancel` killed only the detached worker process, orphaning the `cursor-agent` child it had spawned. The orphan kept editing files and consuming Cursor credits while `/cursor:status` reported the job as `cancelled`.

Root cause: `spawnBackground()` starts the worker with `detached: true` (its own process group, `delegate.mjs` / `review.mjs`), the worker spawns `cursor-agent` as a plain child (same group), but `cancelJob()` signalled only `job.pid`.

## Changes

- New `scripts/lib/kill.mjs#killTree(pid, signal)`:
  - POSIX: `kill(-pid)` to reach the whole group; falls back to a single-pid kill when the recorded pid is not a group leader (the foreground-job case), matching the old behaviour there.
  - Windows: `taskkill /PID <pid> /T /F`.
- `cancelJob()` uses `killTree` for both the initial SIGTERM and the post-grace SIGKILL.
- CHANGELOG entry under Unreleased; `kill` added to the lib list in AGENTS.md.

## Test plan

- New `tests/kill.test.mjs`: pid validation, single-pid fallback for a non-group-leader, `false` when nothing answers.
- New case in `tests/jobs.test.mjs` reproducing the exact background shape (detached group-leader worker + long-running child): cancel must kill **both** processes. Skipped on win32.
- `npm test`: 93/93 green. `npm run lint`: clean.
