### PR TITLE
release: 0.5.0 — session lifecycle hooks, stop review gate, process-group cancel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.5.0 — session lifecycle hooks, stop review gate, process-group cancel
+
+Second port wave from upstream [`openai/codex-plugin-cc`](https://github.com/openai/codex-plugin-cc) (session tracking, the stop-time review gate, prompt templates, structured review output), adapted to the Cursor CLI and the zero-deps runtime — plus a real cancellation bug found while comparing the two codebases. (#17, #18, #20, #21)
 
 ### Added
 

--- a/plugins/cursor/package-lock.json
+++ b/plugins/cursor/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cursor-plugin-cc",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cursor-plugin-cc",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.16.0",

--- a/plugins/cursor/package.json
+++ b/plugins/cursor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cursor-plugin-cc",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Use Cursor CLI from Claude Code to delegate coding tasks to Composer and other Cursor models.",
   "type": "module",
   "license": "MIT",

--- a/plugins/cursor/plugin.json
+++ b/plugins/cursor/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cursor",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Hand off tasks from Claude Code to cursor-agent. Composer-optimised.",
   "author": {
     "name": "Tomas Grasl",


### PR DESCRIPTION
## Summary

Release housekeeping for 0.5.0: consolidates the Unreleased changelog into a `0.5.0` section covering #17, #18, #20, #21, and bumps the version in `package.json`, `package-lock.json`, and `plugin.json`.

Tag `v0.5.0` + GitHub release follow after merge.

## Test plan

- `npm test`: 123/123 green. `npm run lint` + `npm run typecheck`: clean.